### PR TITLE
Refactor UniFi Gateway integration with coordinator-driven sensors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,19 +1,84 @@
 
 from __future__ import annotations
+
 import logging
-from homeassistant.core import HomeAssistant
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
-from .const import DOMAIN, PLATFORMS
+
+from .const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SITE_ID,
+    CONF_TIMEOUT,
+    CONF_USE_PROXY_PREFIX,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    DEFAULT_PORT,
+    DEFAULT_SITE,
+    DEFAULT_TIMEOUT,
+    DEFAULT_USE_PROXY_PREFIX,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    PLATFORMS,
+)
+from .coordinator import UniFiGatewayDataUpdateCoordinator
+from .unifi_client import APIError, AuthError, ConnectivityError, UniFiOSClient
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    hass.data.setdefault(DOMAIN, {})
     return True
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    hass.data.setdefault(DOMAIN, {})
+
+    client_kwargs: dict[str, Any] = {
+        "host": entry.data[CONF_HOST],
+        "username": entry.data[CONF_USERNAME],
+        "password": entry.data[CONF_PASSWORD],
+        "port": entry.data.get(CONF_PORT, DEFAULT_PORT),
+        "site_id": entry.data.get(CONF_SITE_ID, DEFAULT_SITE),
+        "ssl_verify": entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+        "use_proxy_prefix": entry.data.get(CONF_USE_PROXY_PREFIX, DEFAULT_USE_PROXY_PREFIX),
+        "timeout": entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+        "instance_hint": "sensor",
+    }
+
+    try:
+        client: UniFiOSClient = await hass.async_add_executor_job(
+            UniFiOSClient, **client_kwargs
+        )
+    except AuthError as err:
+        raise ConfigEntryAuthFailed("Authentication with UniFi controller failed") from err
+    except ConnectivityError as err:
+        raise ConfigEntryNotReady(f"Cannot connect to UniFi controller: {err}") from err
+    except APIError as err:
+        raise ConfigEntryNotReady(f"UniFi controller error: {err}") from err
+
+    coordinator = UniFiGatewayDataUpdateCoordinator(hass, client)
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "client": client,
+        "coordinator": coordinator,
+    }
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        stored = hass.data.get(DOMAIN)
+        if stored and entry.entry_id in stored:
+            stored.pop(entry.entry_id)
+    return unload_ok

--- a/const.py
+++ b/const.py
@@ -1,6 +1,8 @@
 
+from homeassistant.const import Platform
+
 DOMAIN = "unifi_gateway_refactored"
-PLATFORMS = ["sensor"]
+PLATFORMS = [Platform.SENSOR]
 
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import logging
+from typing import Any, Dict, List, Optional
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+from .unifi_client import APIError, ConnectivityError, UniFiOSClient
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class UniFiGatewayData:
+    """Container describing the data returned by the coordinator."""
+
+    controller: Dict[str, Any]
+    health: List[Dict[str, Any]]
+    health_by_subsystem: Dict[str, Dict[str, Any]]
+    wan_health: List[Dict[str, Any]]
+    alerts: List[Dict[str, Any]]
+    devices: List[Dict[str, Any]]
+    wan_links: List[Dict[str, Any]]
+    networks: List[Dict[str, Any]]
+    lan_networks: List[Dict[str, Any]]
+    network_map: Dict[str, Dict[str, Any]]
+    wlans: List[Dict[str, Any]]
+    clients: List[Dict[str, Any]]
+    vpn_servers: List[Dict[str, Any]]
+    vpn_clients: List[Dict[str, Any]]
+    speedtest: Optional[Dict[str, Any]]
+
+
+class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData]):
+    """Coordinate UniFi Gateway data retrieval for Home Assistant entities."""
+
+    def __init__(self, hass: HomeAssistant, client: UniFiOSClient) -> None:
+        self.client = client
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name=f"{DOMAIN} data",
+            update_interval=timedelta(seconds=30),
+        )
+
+    async def _async_update_data(self) -> UniFiGatewayData:
+        try:
+            return await self.hass.async_add_executor_job(self._fetch_data)
+        except (ConnectivityError, APIError) as err:
+            raise UpdateFailed(str(err)) from err
+
+    def _fetch_data(self) -> UniFiGatewayData:
+        controller_info = {
+            "url": self.client.get_controller_url(),
+            "site": self.client.get_site(),
+        }
+
+        health = self.client.get_healthinfo() or []
+        health_by_subsystem: Dict[str, Dict[str, Any]] = {}
+        wan_health: List[Dict[str, Any]] = []
+        for record in health:
+            subsystem = str(record.get("subsystem") or "").lower()
+            if subsystem:
+                health_by_subsystem[subsystem] = record
+            if subsystem in {"wan", "www", "internet"}:
+                wan_health.append(record)
+
+        alerts_raw = self.client.get_alerts() or []
+        alerts = [alert for alert in alerts_raw if not alert.get("archived")]
+        devices = self.client.get_devices() or []
+
+        networks = self.client.get_networks() or []
+        lan_networks: List[Dict[str, Any]] = []
+        network_map: Dict[str, Dict[str, Any]] = {}
+        for net in networks:
+            nid = net.get("_id") or net.get("id")
+            if nid:
+                network_map[str(nid)] = {
+                    "id": nid,
+                    "name": net.get("name"),
+                    "vlan": net.get("vlan"),
+                    "subnet": net.get("subnet")
+                    or net.get("ip_subnet")
+                    or net.get("cidr"),
+                    "purpose": net.get("purpose") or net.get("role"),
+                }
+            purpose = str(net.get("purpose") or net.get("role") or "").lower()
+            name = net.get("name") or ""
+            if "vpn" in purpose or "wan" in purpose or net.get("is_vpn") or net.get("wan_network"):
+                continue
+            if "wan" in name.lower():
+                continue
+            lan_networks.append(net)
+
+        wan_links_raw = self.client.get_wan_links() or []
+        if not wan_links_raw:
+            wan_links_raw = self._derive_wan_links_from_networks(networks)
+        wan_links: List[Dict[str, Any]] = []
+        for link in wan_links_raw:
+            link_id = link.get("id") or link.get("_id") or link.get("ifname")
+            link_name = link.get("name") or link.get("display_name")
+            if not link_id:
+                link_id = link_name or link.get("isp") or link.get("type") or "wan"
+            if not link_name:
+                link_name = str(link_id)
+            normalized = dict(link)
+            normalized["id"] = str(link_id)
+            normalized["name"] = link_name
+            wan_links.append(normalized)
+
+        wlans = self.client.get_wlans() or []
+        clients = self.client.get_clients() or []
+        vpn_servers = self.client.get_vpn_servers() or []
+        vpn_clients = self.client.get_vpn_clients() or []
+
+        try:
+            speedtest = self.client.get_last_speedtest(cache_sec=5)
+        except APIError:
+            speedtest = None
+
+        # fire and forget — the method is safe if controller does not support speedtests
+        try:
+            self.client.maybe_start_speedtest(cooldown_sec=3600)
+        except APIError:
+            pass
+
+        return UniFiGatewayData(
+            controller=controller_info,
+            health=health,
+            health_by_subsystem=health_by_subsystem,
+            wan_health=wan_health,
+            alerts=alerts,
+            devices=devices,
+            wan_links=wan_links,
+            networks=networks,
+            lan_networks=lan_networks,
+            network_map=network_map,
+            wlans=wlans,
+            clients=clients,
+            vpn_servers=vpn_servers,
+            vpn_clients=vpn_clients,
+            speedtest=speedtest,
+        )
+
+    def _derive_wan_links_from_networks(
+        self, networks: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        wan_candidates: List[Dict[str, Any]] = []
+        for net in networks:
+            purpose = str(net.get("purpose") or net.get("role") or "").lower()
+            name = net.get("name") or ""
+            if "wan" in purpose or net.get("wan_network") or "wan" in name.lower():
+                wan_candidates.append(
+                    {
+                        "id": net.get("_id") or net.get("id") or name or "wan",
+                        "name": name or "WAN",
+                        "type": net.get("purpose") or net.get("role") or "wan",
+                    }
+                )
+        return wan_candidates

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,26 +1,62 @@
 
 from __future__ import annotations
-from typing import Any, Dict
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from .const import (
-    CONF_USERNAME, CONF_PASSWORD, CONF_HOST, CONF_PORT, CONF_SITE_ID,
-    CONF_VERIFY_SSL, CONF_USE_PROXY_PREFIX, CONF_TIMEOUT
-)
-from .unifi_client import UniFiOSClient, APIError, AuthError, ConnectivityError
 
-async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> Dict[str, Any]:
-    data = entry.data
-    def _sync():
+from typing import Any, Dict
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SITE_ID,
+    CONF_TIMEOUT,
+    CONF_USE_PROXY_PREFIX,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    DEFAULT_PORT,
+    DEFAULT_SITE,
+    DEFAULT_TIMEOUT,
+    DEFAULT_USE_PROXY_PREFIX,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+)
+from .unifi_client import UniFiOSClient
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Dict[str, Any]:
+    stored = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+
+    if stored and isinstance(stored.get("client"), UniFiOSClient):
+        client: UniFiOSClient = stored["client"]
+
+        def _collect_existing() -> Dict[str, Any]:
+            health = client.get_healthinfo()
+            sites = client.list_sites()
+            return {
+                "controller_ui": client.get_controller_url(),
+                "site": client.get_site(),
+                "health": health,
+                "sites": sites,
+            }
+
+        return await hass.async_add_executor_job(_collect_existing)
+
+    def _collect_fresh() -> Dict[str, Any]:
         client = UniFiOSClient(
-            host=data[CONF_HOST],
-            username=data[CONF_USERNAME],
-            password=data[CONF_PASSWORD],
-            port=data.get(CONF_PORT, 443),
-            site_id=data.get(CONF_SITE_ID, "default"),
-            ssl_verify=data.get(CONF_VERIFY_SSL, False),
-            use_proxy_prefix=data.get(CONF_USE_PROXY_PREFIX, True),
-            timeout=data.get(CONF_TIMEOUT, 10),
+            host=entry.data[CONF_HOST],
+            username=entry.data[CONF_USERNAME],
+            password=entry.data[CONF_PASSWORD],
+            port=entry.data.get(CONF_PORT, DEFAULT_PORT),
+            site_id=entry.data.get(CONF_SITE_ID, DEFAULT_SITE),
+            ssl_verify=entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+            use_proxy_prefix=entry.data.get(
+                CONF_USE_PROXY_PREFIX, DEFAULT_USE_PROXY_PREFIX
+            ),
+            timeout=entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
         )
         health = client.get_healthinfo()
         sites = client.list_sites()
@@ -30,4 +66,5 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
             "health": health,
             "sites": sites,
         }
-    return await hass.async_add_executor_job(_sync)
+
+    return await hass.async_add_executor_job(_collect_fresh)


### PR DESCRIPTION
## Summary
- add a UniFi Gateway data update coordinator to centralize controller polling and share data across entities
- rebuild the sensor platform around the coordinator with coordinator entities, dynamic discovery, and richer attributes
- harden the UniFi OS client and diagnostics helpers for reuse during setup and troubleshooting

## Testing
- python -m compileall unifi_gatway_refacoty

------
https://chatgpt.com/codex/tasks/task_b_68cfcdae527883279073329f6345ab34