### PR TITLE
Fix invalid translation JSON to restore HACS compatibility

### DIFF
--- a/custom_components/unifi_gateway_refactored/strings.json
+++ b/custom_components/unifi_gateway_refactored/strings.json
@@ -3,7 +3,36 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Gateway",
-        "description": "Enter local admin credentials for UniFi Network Application. We'll validate by fetching health and sites.",
+        "description": "Enter local admin credentials for the UniFi Network Application. We'll validate by fetching health and sites.",
+        "data": {
+          "host": "Host (UDM IP)",
+          "username": "Username (local admin)",
+          "password": "Password",
+          "verify_ssl": "Verify SSL (bool or CA path)"
+        }
+      },
+      "advanced": {
+        "title": "Advanced controller options",
+        "description": "Configure optional controller settings before finishing setup.",
+        "data": {
+          "port": "Port",
+          "site_id": "Site ID",
+          "use_proxy_prefix": "Use /proxy/network prefix",
+          "timeout": "HTTP timeout (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid username or password.",
+      "cannot_connect": "Cannot connect to UniFi host.",
+      "unknown": "Unknown error."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "UniFi Gateway Options",
+        "description": "Update the connection details or advanced controller settings.",
         "data": {
           "host": "Host (UDM IP)",
           "port": "Port",
@@ -20,23 +49,6 @@
       "invalid_auth": "Invalid username or password.",
       "cannot_connect": "Cannot connect to UniFi host.",
       "unknown": "Unknown error."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "UniFi Gateway Options",
-        "data": {
-          "host": "Host (UDM IP)",
-          "port": "Port",
-          "username": "Username (local admin)",
-          "password": "Password",
-          "site_id": "Site ID",
-          "verify_ssl": "Verify SSL (bool or CA path)",
-          "use_proxy_prefix": "Use /proxy/network prefix",
-          "timeout": "HTTP timeout (seconds)"
-        }
-      }
     }
   },
   "title": "UniFi Gateway (Refactored)"

--- a/custom_components/unifi_gateway_refactored/translations/en.json
+++ b/custom_components/unifi_gateway_refactored/translations/en.json
@@ -3,7 +3,36 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Gateway",
-        "description": "Enter local admin credentials for UniFi Network Application. We'll validate by fetching health and sites.",
+        "description": "Enter local admin credentials for the UniFi Network Application. We'll validate by fetching health and sites.",
+        "data": {
+          "host": "Host (UDM IP)",
+          "username": "Username (local admin)",
+          "password": "Password",
+          "verify_ssl": "Verify SSL (bool or CA path)"
+        }
+      },
+      "advanced": {
+        "title": "Advanced controller options",
+        "description": "Configure optional controller settings before finishing setup.",
+        "data": {
+          "port": "Port",
+          "site_id": "Site ID",
+          "use_proxy_prefix": "Use /proxy/network prefix",
+          "timeout": "HTTP timeout (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid username or password.",
+      "cannot_connect": "Cannot connect to UniFi host.",
+      "unknown": "Unknown error."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "UniFi Gateway Options",
+        "description": "Update the connection details or advanced controller settings.",
         "data": {
           "host": "Host (UDM IP)",
           "port": "Port",
@@ -20,23 +49,6 @@
       "invalid_auth": "Invalid username or password.",
       "cannot_connect": "Cannot connect to UniFi host.",
       "unknown": "Unknown error."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "UniFi Gateway Options",
-        "data": {
-          "host": "Host (UDM IP)",
-          "port": "Port",
-          "username": "Username (local admin)",
-          "password": "Password",
-          "site_id": "Site ID",
-          "verify_ssl": "Verify SSL (bool or CA path)",
-          "use_proxy_prefix": "Use /proxy/network prefix",
-          "timeout": "HTTP timeout (seconds)"
-        }
-      }
     }
   },
   "title": "UniFi Gateway (Refactored)"

--- a/custom_components/unifi_gateway_refactored/translations/pl.json
+++ b/custom_components/unifi_gateway_refactored/translations/pl.json
@@ -3,83 +3,53 @@
     "step": {
       "user": {
         "title": "Połącz z UniFi Gateway",
-        "description": "Wprowadź dane połączenia do kontrolera UniFi",
+        "description": "Wprowadź dane lokalnego administratora aplikacji UniFi Network. Podczas zapisu sprawdzimy zdrowie kontrolera i listę witryn.",
         "data": {
-          "host": "Adres hosta kontrolera",
+          "host": "Adres kontrolera (UDM IP)",
+          "username": "Nazwa użytkownika (lokalny administrator)",
+          "password": "Hasło",
+          "verify_ssl": "Weryfikuj SSL (wartość logiczna lub ścieżka do CA)"
+        }
+      },
+      "advanced": {
+        "title": "Zaawansowane opcje kontrolera",
+        "description": "Skonfiguruj dodatkowe ustawienia kontrolera przed zakończeniem konfiguracji.",
+        "data": {
           "port": "Port",
-          "api_key": "Token API",
-          "verify_ssl": "Weryfikuj SSL",
-          "use_proxy_prefix": "Użyj prefiksu proxy (/proxy/network)",
-          "site_id": "Identyfikator strony (site ID)"
+          "site_id": "Identyfikator witryny (site ID)",
+          "use_proxy_prefix": "Użyj prefiksu /proxy/network",
+          "timeout": "Limit czasu żądania HTTP (sekundy)"
         }
       }
     },
     "error": {
-      "auth": "Błąd uwierzytelniania – sprawdź token API",
-      "cannot_connect": "Nie można połączyć się z kontrolerem",
-      "unknown": "Nieznany błąd"
-    },
-    "abort": {
-      "already_configured": "Ten kontroler UniFi jest już skonfigurowany"
+      "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
+      "cannot_connect": "Nie można połączyć się z kontrolerem UniFi.",
+      "unknown": "Nieznany błąd."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Zmień opcje UniFi Gateway",
+        "title": "Opcje UniFi Gateway",
+        "description": "Zaktualizuj szczegóły połączenia lub ustawienia zaawansowane kontrolera.",
         "data": {
-          "scan_interval": "Interwał odświeżania (sekundy)",
-          "monitored_conditions": "Monitorowane warunki"
+          "host": "Adres kontrolera (UDM IP)",
+          "port": "Port",
+          "username": "Nazwa użytkownika (lokalny administrator)",
+          "password": "Hasło",
+          "site_id": "Identyfikator witryny (site ID)",
+          "verify_ssl": "Weryfikuj SSL (wartość logiczna lub ścieżka do CA)",
+          "use_proxy_prefix": "Użyj prefiksu /proxy/network",
+          "timeout": "Limit czasu żądania HTTP (sekundy)"
         }
       }
+    },
+    "error": {
+      "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
+      "cannot_connect": "Nie można połączyć się z kontrolerem UniFi.",
+      "unknown": "Nieznany błąd."
     }
   },
-  "entity": {
-    "sensor": {
-      "wan_ip": {
-        "name": "Adres IP WAN",
-        "icon": "mdi:ip-network"
-      },
-      "wan_isp": {
-        "name": "Dostawca internetu (ISP)",
-        "icon": "mdi:office-building"
-      },
-      "vpn_clients": {
-        "name": "Klienci VPN",
-        "icon": "mdi:lock"
-      },
-      "vpn_servers": {
-        "name": "Serwery VPN",
-        "icon": "mdi:server-network"
-      },
-      "wlan_clients": {
-        "name": "Klienci WLAN",
-        "icon": "mdi:wifi"
-      },
-      "lan_clients": {
-        "name": "Klienci LAN",
-        "icon": "mdi:lan"
-      },
-      "alerts": {
-        "name": "Alerty",
-        "icon": "mdi:alert"
-      },
-      "firmware": {
-        "name": "Dostępne aktualizacje firmware",
-        "icon": "mdi:database-plus"
-      },
-      "speedtest_down": {
-        "name": "Prędkość pobierania",
-        "icon": "mdi:progress-download"
-      },
-      "speedtest_up": {
-        "name": "Prędkość wysyłania",
-        "icon": "mdi:progress-upload"
-      },
-      "speedtest_ping": {
-        "name": "Opóźnienie (ping)",
-        "icon": "mdi:progress-clock"
-      }
-    }
-  }
+  "title": "UniFi Gateway (Refactored)"
 }


### PR DESCRIPTION
## Summary
- rewrite strings.json and translations to valid JSON so HACS can parse metadata
- split configuration flow strings between user and advanced steps and add shared error text
- sync Polish translation with current fields and remove obsolete sensor keys

## Testing
- python -m json.tool custom_components/unifi_gateway_refactored/strings.json
- python -m json.tool custom_components/unifi_gateway_refactored/translations/en.json
- python -m json.tool custom_components/unifi_gateway_refactored/translations/pl.json

------
https://chatgpt.com/codex/tasks/task_b_68cff9cb6f748327b872ab22a9a98110