### PR TITLE
Add hacs.json metadata for HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "UniFi Gateway (Refactored)",
+  "filename": "custom_components/unifi_gateway_refactored/manifest.json",
+  "render_readme": true
+}


### PR DESCRIPTION
## Summary
- add hacs.json metadata so the repository can be installed via HACS

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68cffb1304e083278ca8997fa0fa4a5c