### PR TITLE
Automate HACS release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Create release from manifest version
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - custom_components/unifi_gateway_refactored/manifest.json
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Tag and publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from manifest
+        id: manifest
+        run: |
+          VERSION=$(python - <<'PY'
+import json
+from pathlib import Path
+manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
+print(manifest["version"])
+PY
+          )
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate semantic version
+        run: |
+          python - <<'PY'
+import re
+version = "${{ steps.manifest.outputs.version }}"
+if not re.fullmatch(r"\d+\.\d+\.\d+(?:[ab]\d+)?", version):
+    raise SystemExit(
+        "Manifest version '%s' is not a valid semantic version (major.minor.patch)." % version
+    )
+PY
+
+      - name: Check if tag exists
+        id: tag
+        run: |
+          if git rev-parse "${VERSION}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          VERSION: ${{ steps.manifest.outputs.version }}
+
+      - name: Create GitHub release
+        if: steps.tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.manifest.outputs.version }}
+          name: ${{ steps.manifest.outputs.version }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.tag.outputs.exists }}" = "true" ]; then
+            echo "Tag ${{ steps.manifest.outputs.version }} already exists, skipping release." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Created release ${{ steps.manifest.outputs.version }}." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 
-# UniFi Gateway (Refactored) — UI Config Flow + Options + Diagnostics
+# UniFi Gateway (Refactored)
+
+Custom integration for Home Assistant that exposes UniFi Gateway metrics with a
+fully UI-driven configuration flow.
+
+## Features
 
 - **UI-based setup** (no YAML): Add Integration → UniFi Gateway (Refactored).
 - **Live validation on save**: during setup we log in and read `/stat/health` and `/self/sites`.
 - **Options Flow**: you can change host/credentials/site/etc. later from the integration's Options.
 - **Diagnostics**: menu "Download diagnostics" dumps controller URL, current site, health, sites.
 
-Uwierzytelnianie: lokalny **username/password** (jak w sirkirby/unifi-network-rules).
+Authentication uses a local **username/password** (the same approach as in
+[`sirkirby/unifi-network-rules`](https://github.com/sirkirby/unifi-network-rules)).
+
+## Repository layout required by HACS
+
+HACS expects the following files in a custom integration repository:
+
+- `hacs.json` in the repository root.
+- `README.md` (or `info.md`) in the repository root for documentation rendering.
+- `custom_components/<domain>/manifest.json` inside the integration directory.
+
+This repository already follows that layout with the integration stored in
+`custom_components/unifi_gateway_refactored/`.
+
+## Publishing releases for HACS
+
+HACS requires release tags that follow the `MAJOR.MINOR.PATCH` semantic version
+pattern. The workflow is:
+
+1. Update `custom_components/unifi_gateway_refactored/manifest.json` with the new
+   version number and any code changes for the release.
+2. Commit the change and push it to the `main` branch.
+3. GitHub Actions (`.github/workflows/release.yml`) validates the semantic version
+   and, if a tag with that name does not yet exist, automatically creates a tag
+   and GitHub Release with the same version number.
+
+The generated release contains the complete repository (including the
+`custom_components` directory) as required by the
+[HACS publishing guide](https://hacs.xyz/docs/publish/).
 

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway (Refactored)",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "config_flow": true,
-  "documentation": "https://github.com/sirkirby/unifi-network-rules",
-  "issue_tracker": "https://github.com/sirkirby/unifi-network-rules/issues",
+  "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
+  "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",
   "iot_class": "local_polling",
   "requirements": [],
   "codeowners": [

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "UniFi Gateway (Refactored)",
-  "filename": "custom_components/unifi_gateway_refactored/manifest.json",
   "render_readme": true
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest to version 4.1.1 so the next release uses a semantic version
- add a GitHub Actions workflow that validates the manifest version and creates a matching tag/release
- document the HACS release process and required repository layout in the README so maintainers know how releases are generated and structured
- update HACS metadata to point to this repository and remove the unnecessary filename override

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68cffc491fec8327b21b30ec489e16b4