### PR TITLE
Fix release workflow indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,24 +22,26 @@ jobs:
         id: manifest
         run: |
           VERSION=$(python - <<'PY'
-import json
-from pathlib import Path
-manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
-print(manifest["version"])
-PY
+            import json
+            from pathlib import Path
+
+            manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
+            print(manifest["version"])
+          PY
           )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate semantic version
         run: |
           python - <<'PY'
-import re
-version = "${{ steps.manifest.outputs.version }}"
-if not re.fullmatch(r"\d+\.\d+\.\d+(?:[ab]\d+)?", version):
-    raise SystemExit(
-        "Manifest version '%s' is not a valid semantic version (major.minor.patch)." % version
-    )
-PY
+            import re
+
+            version = "${{ steps.manifest.outputs.version }}"
+            if not re.fullmatch(r"\d+\.\d+\.\d+(?:[ab]\d+)?", version):
+                raise SystemExit(
+                    "Manifest version '%s' is not a valid semantic version (major.minor.patch)." % version
+                )
+          PY
 
       - name: Check if tag exists
         id: tag


### PR DESCRIPTION
## Summary
- align the inline Python scripts with the surrounding indentation so the workflow parses correctly
- keep the release workflow logic the same while restoring valid YAML syntax

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cfff91ae40832783e107914a37fe1b