### PR TITLE
Fix UniFi client creation using async_add_executor_job

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -52,10 +53,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "instance_hint": "sensor",
     }
 
+    client_factory = partial(UniFiOSClient, **client_kwargs)
+
     try:
-        client: UniFiOSClient = await hass.async_add_executor_job(
-            UniFiOSClient, **client_kwargs
-        )
+        client: UniFiOSClient = await hass.async_add_executor_job(client_factory)
     except AuthError as err:
         raise ConfigEntryAuthFailed("Authentication with UniFi controller failed") from err
     except ConnectivityError as err:


### PR DESCRIPTION
## Summary
- create the UniFi client via a functools.partial when running in the executor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d00267c45c8327a6437e3e4566a571