### PR TITLE
Improve WAN, VPN metrics and add branding assets

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -57,6 +57,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
     def _fetch_data(self) -> UniFiGatewayData:
         controller_info = {
             "url": self.client.get_controller_url(),
+            "api_url": self.client.get_controller_api_url(),
             "site": self.client.get_site(),
         }
 

--- a/custom_components/unifi_gateway_refactored/diagnostics.py
+++ b/custom_components/unifi_gateway_refactored/diagnostics.py
@@ -38,6 +38,7 @@ async def async_get_config_entry_diagnostics(
             sites = client.list_sites()
             return {
                 "controller_ui": client.get_controller_url(),
+                "controller_api": client.get_controller_api_url(),
                 "site": client.get_site(),
                 "health": health,
                 "sites": sites,
@@ -62,6 +63,7 @@ async def async_get_config_entry_diagnostics(
         sites = client.list_sites()
         return {
             "controller_ui": client.get_controller_url(),
+            "controller_api": client.get_controller_api_url(),
             "site": client.get_site(),
             "health": health,
             "sites": sites,

--- a/custom_components/unifi_gateway_refactored/icon.svg
+++ b/custom_components/unifi_gateway_refactored/icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>UniFi Gateway Refactored Icon</title>
+  <defs>
+    <linearGradient id="icon-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f9dd1"/>
+      <stop offset="100%" stop-color="#0f4c81"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#icon-grad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M64 26c-20 0-36 16-36 36s16 36 36 36 36-16 36-36" opacity="0.4"/>
+    <path d="M64 42c-12 0-22 10-22 22s10 22 22 22 22-10 22-22"/>
+  </g>
+  <circle cx="64" cy="64" r="10" fill="#ffffff"/>
+</svg>

--- a/custom_components/unifi_gateway_refactored/logo.svg
+++ b/custom_components/unifi_gateway_refactored/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title>UniFi Gateway Refactored Logo</title>
+  <desc>Stylised gateway shield with wireless waves.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f9dd1"/>
+      <stop offset="100%" stop-color="#0f4c81"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="48" fill="url(#grad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 56c-40 0-72 32-72 72s32 72 72 72 72-32 72-72" opacity="0.35"/>
+    <path d="M128 80c-28 0-52 24-52 52s24 52 52 52 52-24 52-52" opacity="0.6"/>
+    <path d="M128 104c-16 0-32 16-32 32s16 32 32 32 32-16 32-32"/>
+  </g>
+  <path fill="#ffffff" d="M128 36l54 24v52c0 42-23 80-54 96-31-16-54-54-54-96V60z" opacity="0.08"/>
+  <path fill="#ffffff" d="M116 140h24v52h-24z" opacity="0.85"/>
+  <circle cx="128" cy="128" r="20" fill="#ffffff"/>
+</svg>

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -13,5 +13,7 @@
   "integration_type": "hub",
   "loggers": [
     "custom_components.unifi_gateway_refactored"
-  ]
+  ],
+  "logo": "logo.svg",
+  "icon": "icon.svg"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "UniFi Gateway (Refactored)",
-  "render_readme": true
+  "render_readme": true,
+  "logo": "custom_components/unifi_gateway_refactored/logo.svg",
+  "icon": "custom_components/unifi_gateway_refactored/icon.svg"
 }


### PR DESCRIPTION
## Summary
- derive controller login URL and expose the API root alongside it in entity attributes and diagnostics
- enhance WAN status/IP/ISP sensors with WAN health fallbacks so values are populated reliably and add richer metadata
- collect VPN servers/clients from nested API payloads and expose the requested attributes for each sensor
- add branded logo/icon files and wire them up for both Home Assistant and HACS listings

## Testing
- `python -m compileall custom_components/unifi_gateway_refactored`


------
https://chatgpt.com/codex/tasks/task_b_68d0076c2a348327be9b0e08c91a8483