### PR TITLE
Add VPN site-to-site sensors and update assets

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -33,6 +33,7 @@ class UniFiGatewayData:
     clients: List[Dict[str, Any]]
     vpn_servers: List[Dict[str, Any]]
     vpn_clients: List[Dict[str, Any]]
+    vpn_site_to_site: List[Dict[str, Any]]
     speedtest: Optional[Dict[str, Any]]
 
 
@@ -118,6 +119,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
         clients = self.client.get_clients() or []
         vpn_servers = self.client.get_vpn_servers() or []
         vpn_clients = self.client.get_vpn_clients() or []
+        vpn_site_to_site = self.client.get_vpn_site_to_site() or []
 
         try:
             speedtest = self.client.get_last_speedtest(cache_sec=5)
@@ -145,6 +147,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             clients=clients,
             vpn_servers=vpn_servers,
             vpn_clients=vpn_clients,
+            vpn_site_to_site=vpn_site_to_site,
             speedtest=speedtest,
         )
 

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway (Refactored)",
-  "version": "4.1.1",
+  "version": "0.0.1",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "UniFi Gateway (Refactored)",
   "render_readme": true,
-  "logo": "custom_components/unifi_gateway_refactored/logo.svg",
-  "icon": "custom_components/unifi_gateway_refactored/icon.svg"
+  "logo": "images/logo.svg",
+  "icon": "images/icon.svg"
 }

--- a/images/icon.svg
+++ b/images/icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>UniFi Gateway Refactored Icon</title>
+  <defs>
+    <linearGradient id="icon-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f9dd1"/>
+      <stop offset="100%" stop-color="#0f4c81"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#icon-grad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M64 26c-20 0-36 16-36 36s16 36 36 36 36-16 36-36" opacity="0.4"/>
+    <path d="M64 42c-12 0-22 10-22 22s10 22 22 22 22-10 22-22"/>
+  </g>
+  <circle cx="64" cy="64" r="10" fill="#ffffff"/>
+</svg>

--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title>UniFi Gateway Refactored Logo</title>
+  <desc>Stylised gateway shield with wireless waves.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f9dd1"/>
+      <stop offset="100%" stop-color="#0f4c81"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="48" fill="url(#grad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 56c-40 0-72 32-72 72s32 72 72 72 72-32 72-72" opacity="0.35"/>
+    <path d="M128 80c-28 0-52 24-52 52s24 52 52 52 52-24 52-52" opacity="0.6"/>
+    <path d="M128 104c-16 0-32 16-32 32s16 32 32 32 32-16 32-32"/>
+  </g>
+  <path fill="#ffffff" d="M128 36l54 24v52c0 42-23 80-54 96-31-16-54-54-54-96V60z" opacity="0.08"/>
+  <path fill="#ffffff" d="M116 140h24v52h-24z" opacity="0.85"/>
+  <circle cx="128" cy="128" r="20" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- classify UniFi VPN records and expose server, client, and site-to-site entities while migrating legacy unique IDs
- include site-to-site data in the coordinator so the new sensors can be created
- update the manifest version and provide SVG logo/icon assets referenced by HACS

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d0322c38c08327a6429c390153fd2c