### PR TITLE
Fix indentation in release workflow Python blocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
         id: manifest
         run: |
           VERSION=$(python - <<'PY'
-            import json
-            from pathlib import Path
+          import json
+          from pathlib import Path
 
-            manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
-            print(manifest["version"])
+          manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
+          print(manifest["version"])
           PY
           )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -34,13 +34,13 @@ jobs:
       - name: Validate semantic version
         run: |
           python - <<'PY'
-            import re
+          import re
 
-            version = "${{ steps.manifest.outputs.version }}"
-            if not re.fullmatch(r"\d+\.\d+\.\d+(?:[ab]\d+)?", version):
-                raise SystemExit(
-                    "Manifest version '%s' is not a valid semantic version (major.minor.patch)." % version
-                )
+          version = "${{ steps.manifest.outputs.version }}"
+          if not re.fullmatch(r"\d+\.\d+\.\d+(?:[ab]\d+)?", version):
+              raise SystemExit(
+                  "Manifest version '%s' is not a valid semantic version (major.minor.patch)." % version
+              )
           PY
 
       - name: Check if tag exists


### PR DESCRIPTION
## Summary
- align the inline Python scripts in the release workflow with the surrounding shell code so they execute without indentation errors
- ensure both the manifest version extraction and semantic version validation steps run correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68d037e98fe8832796aab2f5d8307349