### PR TITLE
Improve UniFi Gateway logging for VPN discovery

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -56,13 +56,23 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             raise UpdateFailed(str(err)) from err
 
     def _fetch_data(self) -> UniFiGatewayData:
+        _LOGGER.debug(
+            "Starting UniFi Gateway data fetch for instance %s",
+            self.client.instance_key(),
+        )
         controller_info = {
             "url": self.client.get_controller_url(),
             "api_url": self.client.get_controller_api_url(),
             "site": self.client.get_site(),
         }
+        _LOGGER.debug(
+            "Controller context: url=%s site=%s",
+            controller_info["api_url"],
+            controller_info["site"],
+        )
 
         health = self.client.get_healthinfo() or []
+        _LOGGER.debug("Retrieved %s health records", len(health))
         health_by_subsystem: Dict[str, Dict[str, Any]] = {}
         wan_health: List[Dict[str, Any]] = []
         for record in health:
@@ -74,9 +84,14 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
 
         alerts_raw = self.client.get_alerts() or []
         alerts = [alert for alert in alerts_raw if not alert.get("archived")]
+        _LOGGER.debug(
+            "Retrieved %s active alerts (raw=%s)", len(alerts), len(alerts_raw)
+        )
         devices = self.client.get_devices() or []
+        _LOGGER.debug("Retrieved %s devices", len(devices))
 
         networks = self.client.get_networks() or []
+        _LOGGER.debug("Retrieved %s networks", len(networks))
         lan_networks: List[Dict[str, Any]] = []
         network_map: Dict[str, Dict[str, Any]] = {}
         for net in networks:
@@ -98,10 +113,15 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             if "wan" in name.lower():
                 continue
             lan_networks.append(net)
+        _LOGGER.debug("Identified %s LAN networks", len(lan_networks))
 
         wan_links_raw = self.client.get_wan_links() or []
         if not wan_links_raw:
             wan_links_raw = self._derive_wan_links_from_networks(networks)
+            _LOGGER.warning(
+                "WAN link discovery required fallback derivation; derived=%s",
+                len(wan_links_raw),
+            )
         wan_links: List[Dict[str, Any]] = []
         for link in wan_links_raw:
             link_id = link.get("id") or link.get("_id") or link.get("ifname")
@@ -114,25 +134,38 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             normalized["id"] = str(link_id)
             normalized["name"] = link_name
             wan_links.append(normalized)
+        _LOGGER.debug("Processed %s WAN link records", len(wan_links))
 
         wlans = self.client.get_wlans() or []
+        _LOGGER.debug("Retrieved %s WLAN configurations", len(wlans))
         clients = self.client.get_clients() or []
+        _LOGGER.debug("Retrieved %s clients", len(clients))
         vpn_servers = self.client.get_vpn_servers() or []
         vpn_clients = self.client.get_vpn_clients() or []
         vpn_site_to_site = self.client.get_vpn_site_to_site() or []
+        _LOGGER.debug(
+            "VPN records: servers=%s clients=%s site_to_site=%s",
+            len(vpn_servers),
+            len(vpn_clients),
+            len(vpn_site_to_site),
+        )
 
         try:
             speedtest = self.client.get_last_speedtest(cache_sec=5)
-        except APIError:
+            if speedtest:
+                _LOGGER.debug("Retrieved cached speedtest result")
+        except APIError as err:
+            _LOGGER.warning("Fetching last speedtest failed: %s", err)
             speedtest = None
 
         # fire and forget — the method is safe if controller does not support speedtests
         try:
             self.client.maybe_start_speedtest(cooldown_sec=3600)
-        except APIError:
-            pass
+            _LOGGER.debug("Speedtest trigger evaluated")
+        except APIError as err:
+            _LOGGER.debug("Speedtest trigger failed: %s", err)
 
-        return UniFiGatewayData(
+        data = UniFiGatewayData(
             controller=controller_info,
             health=health,
             health_by_subsystem=health_by_subsystem,
@@ -150,6 +183,13 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             vpn_site_to_site=vpn_site_to_site,
             speedtest=speedtest,
         )
+        _LOGGER.debug(
+            "Completed data fetch: health=%s alerts=%s devices=%s",
+            len(data.health),
+            len(data.alerts),
+            len(data.devices),
+        )
+        return data
 
     def _derive_wan_links_from_networks(
         self, networks: List[Dict[str, Any]]

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import ipaddress
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -14,6 +15,9 @@ from .coordinator import UniFiGatewayData, UniFiGatewayDataUpdateCoordinator
 from .unifi_client import UniFiOSClient, vpn_peer_identity
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 SUBSYSTEM_SENSORS: Dict[str, tuple[str, str]] = {
     "wan": ("WAN", "mdi:shield-outline"),
     "lan": ("LAN", "mdi:lan"),
@@ -25,6 +29,9 @@ SUBSYSTEM_SENSORS: Dict[str, tuple[str, str]] = {
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
+    _LOGGER.debug(
+        "Setting up UniFi Gateway sensors for config entry %s", entry.entry_id
+    )
     data = hass.data[DOMAIN][entry.entry_id]
     client: UniFiOSClient = data["client"]
     coordinator: UniFiGatewayDataUpdateCoordinator = data["coordinator"]
@@ -40,6 +47,11 @@ async def async_setup_entry(
     static_entities.append(UniFiGatewaySpeedtestUploadSensor(coordinator, client))
     static_entities.append(UniFiGatewaySpeedtestPingSensor(coordinator, client))
 
+    _LOGGER.debug(
+        "Adding %s static sensors for entry %s",
+        len(static_entities),
+        entry.entry_id,
+    )
     async_add_entities(static_entities)
 
     known_wan: set[str] = set()
@@ -50,8 +62,15 @@ async def async_setup_entry(
     known_vpn_site_to_site: set[str] = set()
 
     def _sync_dynamic() -> None:
+        _LOGGER.debug(
+            "Synchronizing dynamic UniFi Gateway sensors for entry %s",
+            entry.entry_id,
+        )
         coordinator_data: Optional[UniFiGatewayData] = coordinator.data
         if coordinator_data is None:
+            _LOGGER.debug(
+                "Coordinator data unavailable during sync for entry %s", entry.entry_id
+            )
             return
 
         new_entities: List[SensorEntity] = []
@@ -115,7 +134,21 @@ async def async_setup_entry(
             )
 
         if new_entities:
+            names = [
+                getattr(entity, "name", entity.__class__.__name__)
+                for entity in new_entities
+            ]
+            _LOGGER.debug(
+                "Adding %s dynamic sensors for entry %s: %s",
+                len(new_entities),
+                entry.entry_id,
+                names,
+            )
             async_add_entities(new_entities)
+        else:
+            _LOGGER.debug(
+                "No new dynamic sensors discovered for entry %s", entry.entry_id
+            )
 
     _sync_dynamic()
     entry.async_on_unload(coordinator.async_add_listener(_sync_dynamic))

--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -462,6 +462,7 @@ class UniFiOSClient:
             for ep in ("/api/auth/login", "/api/login", "/auth/login"):
                 url = f"{root}{ep}"
                 try:
+                    _LOGGER.debug("Attempting UniFi OS login via endpoint %s", url)
                     r = self._session.post(
                         url,
                         json={
@@ -481,7 +482,13 @@ class UniFiOSClient:
                             self._session.headers["x-csrf-token"] = csrf
                         _LOGGER.info("Logged into UniFi OS via %s", url)
                         return
-                except requests.RequestException:
+                except requests.RequestException as err:
+                    _LOGGER.debug(
+                        "Login attempt against %s raised a transport error: %s",
+                        url,
+                        err,
+                        exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                    )
                     continue
         raise AuthError("Failed to authenticate with provided username/password")
 
@@ -531,6 +538,13 @@ class UniFiOSClient:
         url: str,
         payload: Optional[Dict[str, Any]] = None,
     ) -> Any:
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "UniFi request %s %s (payload=%s)",
+                method,
+                url,
+                "yes" if payload else "no",
+            )
         try:
             r = self._session.request(
                 method,
@@ -540,23 +554,38 @@ class UniFiOSClient:
                 timeout=self._timeout,
             )
         except requests.RequestException as ex:
+            _LOGGER.error("Transport error during UniFi request %s %s: %s", method, url, ex)
             raise ConnectivityError(f"Request error: {ex}") from ex
+        _LOGGER.debug(
+            "UniFi response for %s %s: HTTP %s", method, url, r.status_code
+        )
         if r.status_code in (401, 403):
+            _LOGGER.error("Authentication failed for UniFi request %s %s", method, url)
             raise AuthError(f"Auth failed at {url}")
         if r.status_code >= 400:
+            _LOGGER.error(
+                "HTTP error %s for UniFi request %s %s: %s",
+                r.status_code,
+                method,
+                url,
+                r.text[:200],
+            )
             raise APIError(f"HTTP {r.status_code}: {r.text[:200]} at {url}")
         if not r.content:
             return None
         try:
             data = r.json()
         except ValueError:
+            _LOGGER.error("Invalid JSON received from UniFi request %s %s", method, url)
             raise APIError(f"Invalid JSON from {url}")
         return data.get("data") if isinstance(data, dict) and "data" in data else data
 
     def _get(self, path: str):
+        _LOGGER.debug("GET %s", path)
         return self._request("GET", f"{self._base}/{path.lstrip('/')}")
 
     def _post(self, path: str, payload: Optional[Dict[str, Any]] = None):
+        _LOGGER.debug("POST %s", path)
         return self._request("POST", f"{self._base}/{path.lstrip('/')}", payload)
 
     # ----------- public helpers used by sensors / diagnostics -----------
@@ -572,22 +601,57 @@ class UniFiOSClient:
 
     def get_alerts(self):
         try:
-            return self._get("list/alert")
-        except APIError:
-            return self._get("list/alarm")
+            alerts = self._get("list/alert")
+            _LOGGER.debug(
+                "Fetched %s alert records from list/alert",
+                len(alerts) if isinstance(alerts, list) else "unknown",
+            )
+            return alerts
+        except APIError as err:
+            _LOGGER.warning(
+                "Fetching list/alert failed (%s); attempting legacy list/alarm endpoint",
+                err,
+            )
+            legacy_alerts = self._get("list/alarm")
+            _LOGGER.debug(
+                "Fetched %s alert records from list/alarm",
+                len(legacy_alerts)
+                if isinstance(legacy_alerts, list)
+                else "unknown",
+            )
+            return legacy_alerts
 
     def list_sites(self):
         root = self._base.split("/api/s/")[0] + "/api"
-        return self._request("GET", f"{root}/self/sites")
+        sites = self._request("GET", f"{root}/self/sites")
+        _LOGGER.debug(
+            "Controller returned %s sites", len(sites) if isinstance(sites, list) else "unknown"
+        )
+        return sites
 
     def get_networks(self) -> List[Dict[str, Any]]:
         for path in ("rest/networkconf", "list/networkconf"):
             try:
                 data = self._get(path)
                 if isinstance(data, list):
+                    _LOGGER.debug(
+                        "Fetched %s networks via %s", len(data), path
+                    )
                     return data
-            except APIError:
+                _LOGGER.debug(
+                    "Endpoint %s returned %s instead of list for networks",
+                    path,
+                    type(data).__name__,
+                )
+            except APIError as err:
+                _LOGGER.debug(
+                    "Network fetch via %s failed: %s",
+                    path,
+                    err,
+                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                )
                 continue
+        _LOGGER.warning("No network configuration data returned by controller")
         return []
 
     def get_wlans(self) -> List[Dict[str, Any]]:
@@ -595,9 +659,24 @@ class UniFiOSClient:
             try:
                 data = self._get(path)
                 if isinstance(data, list):
+                    _LOGGER.debug(
+                        "Fetched %s WLAN configurations via %s", len(data), path
+                    )
                     return data
-            except APIError:
+                _LOGGER.debug(
+                    "Endpoint %s returned %s instead of list for WLANs",
+                    path,
+                    type(data).__name__,
+                )
+            except APIError as err:
+                _LOGGER.debug(
+                    "WLAN fetch via %s failed: %s",
+                    path,
+                    err,
+                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                )
                 continue
+        _LOGGER.warning("No WLAN configuration data returned by controller")
         return []
 
     def get_clients(self) -> List[Dict[str, Any]]:
@@ -605,9 +684,24 @@ class UniFiOSClient:
             try:
                 data = self._get(path)
                 if isinstance(data, list):
+                    _LOGGER.debug(
+                        "Fetched %s clients via %s", len(data), path
+                    )
                     return data
-            except APIError:
+                _LOGGER.debug(
+                    "Endpoint %s returned %s instead of list for clients",
+                    path,
+                    type(data).__name__,
+                )
+            except APIError as err:
+                _LOGGER.debug(
+                    "Client fetch via %s failed: %s",
+                    path,
+                    err,
+                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                )
                 continue
+        _LOGGER.warning("No client data returned by controller")
         return []
 
     def get_wan_links(self) -> List[Dict[str, Any]]:
@@ -618,25 +712,47 @@ class UniFiOSClient:
             "list/wan",
             "stat/wan",
         ]
+        _LOGGER.debug("Attempting WAN link discovery via endpoints: %s", ", ".join(paths))
         for path in paths:
             try:
                 data = self._get(path)
-            except Exception:
+            except Exception as err:
+                _LOGGER.debug(
+                    "WAN link fetch via %s failed: %s",
+                    path,
+                    err,
+                    exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+                )
                 continue
             # dict with nested lists
             if isinstance(data, dict):
                 for k in ("wans", "wan_links", "links", "interfaces"):
                     v = data.get(k)
                     if isinstance(v, list) and v:
+                        _LOGGER.debug(
+                            "WAN link data discovered via %s.%s (%s entries)",
+                            path,
+                            k,
+                            len(v),
+                        )
                         return [x for x in v if isinstance(x, dict)]
             # direct list
             if isinstance(data, list) and data:
+                _LOGGER.debug(
+                    "WAN link data discovered via %s (%s entries)",
+                    path,
+                    len(data),
+                )
                 return [x for x in data if isinstance(x, dict)]
         # fallback: derive from networks marked as WAN
         nets = []
         try:
             nets = self.get_networks() or []
-        except Exception:
+        except Exception as err:
+            _LOGGER.warning(
+                "Falling back to deriving WAN links from networks due to error: %s",
+                err,
+            )
             nets = []
         out = []
         for n in nets:
@@ -644,6 +760,12 @@ class UniFiOSClient:
             name = n.get("name") or n.get("display_name") or ""
             if "wan" in purpose or n.get("wan_network") or "wan" in (name or "").lower():
                 out.append({"id": n.get("_id") or n.get("id") or name, "name": name, "type": "wan"})
+        if out:
+            _LOGGER.debug(
+                "Derived %s WAN links from network configuration fallback", len(out)
+            )
+        else:
+            _LOGGER.error("Unable to determine WAN links from controller data")
         return out
 
     def _flatten_vpn_records(
@@ -729,13 +851,27 @@ class UniFiOSClient:
                 continue
 
             flattened = self._flatten_vpn_records(data, role_hint)
+            fallback_used = False
+            if not flattened:
+                legacy_records = self._legacy_vpn_records(data)
+                if legacy_records:
+                    flattened = legacy_records
+                    fallback_used = True
+
             if flattened:
                 _LOGGER.debug(
-                    "VPN probe %s returned %s candidate records for %s",
+                    "VPN probe %s returned %s candidate records for %s%s",
                     path,
                     len(flattened),
                     role_hint or "vpn",
+                    " via legacy parser" if fallback_used else "",
                 )
+                if fallback_used:
+                    _LOGGER.warning(
+                        "VPN probe %s required legacy parser fallback for %s records",
+                        path,
+                        role_hint or "vpn",
+                    )
             else:
                 _LOGGER.debug(
                     "VPN probe %s returned no candidate records for %s (raw type=%s)",
@@ -805,6 +941,48 @@ class UniFiOSClient:
 
         return list(uniq.values())
 
+    def _legacy_vpn_records(self, data: Any) -> List[Dict[str, Any]]:
+        """Fallback parser for VPN records when the structured parser finds none."""
+
+        if data in (None, "", [], {}):
+            return []
+
+        records: List[Dict[str, Any]] = []
+        seen: set[int] = set()
+        stack: List[Any] = [data]
+
+        while stack:
+            current = stack.pop()
+            if isinstance(current, dict):
+                obj_id = id(current)
+                if obj_id in seen:
+                    continue
+                seen.add(obj_id)
+                has_vpn_key = any(
+                    key in current and current.get(key) not in (None, "", [], {})
+                    for key in _VPN_RECORD_KEYS
+                )
+                if has_vpn_key:
+                    records.append(current)
+                for value in current.values():
+                    if isinstance(value, (dict, list)):
+                        stack.append(value)
+            elif isinstance(current, list):
+                obj_id = id(current)
+                if obj_id in seen:
+                    continue
+                seen.add(obj_id)
+                for item in current:
+                    if isinstance(item, (dict, list)):
+                        stack.append(item)
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Legacy VPN parser extracted %s records", len(records)
+            )
+
+        return records
+
     def get_vpn_servers(self) -> List[Dict[str, Any]]:
         """Return configured VPN servers (WireGuard/OpenVPN Remote User)."""
         probes = [
@@ -821,7 +999,11 @@ class UniFiOSClient:
             "rest/wgservers",
             "rest/wireguard/server",
         ]
-        return self._collect_vpn_records(probes, "server", {"server"})
+        servers = self._collect_vpn_records(probes, "server", {"server"})
+        _LOGGER.debug("Returning %s VPN server records", len(servers))
+        if not servers:
+            _LOGGER.warning("Controller returned no VPN server records")
+        return servers
 
     def get_vpn_clients(self) -> List[Dict[str, Any]]:
         """Return configured VPN client tunnels (policy-based/route-based)."""
@@ -837,7 +1019,11 @@ class UniFiOSClient:
             "rest/wgclients",
             "rest/wireguard/client",
         ]
-        return self._collect_vpn_records(probes, "client", {"client", "teleport"})
+        clients = self._collect_vpn_records(probes, "client", {"client", "teleport"})
+        _LOGGER.debug("Returning %s VPN client records", len(clients))
+        if not clients:
+            _LOGGER.warning("Controller returned no VPN client records")
+        return clients
 
     def get_vpn_site_to_site(self) -> List[Dict[str, Any]]:
         """Return configured Site-to-Site tunnels (IPSec/UID)."""
@@ -854,7 +1040,13 @@ class UniFiOSClient:
             "rest/wgclients",
             "rest/wireguard/client",
         ]
-        return self._collect_vpn_records(probes, "site_to_site", {"site_to_site", "uid"})
+        tunnels = self._collect_vpn_records(
+            probes, "site_to_site", {"site_to_site", "uid"}
+        )
+        _LOGGER.debug("Returning %s VPN site-to-site records", len(tunnels))
+        if not tunnels:
+            _LOGGER.warning("Controller returned no site-to-site VPN records")
+        return tunnels
 
     def instance_key(self) -> str:
         return self._iid


### PR DESCRIPTION
## Summary
- add a legacy VPN record parser that walks raw API responses when the structured parser yields nothing
- log when the fallback is used so VPN discovery issues are visible in debug output
- expand Home Assistant logging to cover setup, coordinator refreshes, and VPN data collection with debug, warning, and error levels

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d053c525e08327851254ef4a7774bd