### PR TITLE
Fix VPN peer probe normalization

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -1015,7 +1015,13 @@ class UniFiOSClient:
                 )
                 continue
 
-        main
+            normalized = self._normalize_vpn_payload(
+                payload,
+                path=path,
+                default_category=hint,
+            )
+
+            if not normalized:
                 _LOGGER.debug(
                     "VPN peer probe %s returned no peer records (type=%s)",
                     path,


### PR DESCRIPTION
## Summary
- normalize VPN probe payloads before processing
- skip probes that return no candidate records while logging their payload type

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d05f5386b48327bd5cb017eae0ec06