### PR TITLE
Handle expected WAN endpoint errors gracefully

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -872,7 +872,10 @@ class UniFiOSClient:
         _LOGGER.debug("Attempting WAN link discovery via endpoints: %s", ", ".join(paths))
         for path in paths:
             try:
-                data = self._get(path)
+                data = self._get(
+                    path,
+                    expected_errors=_VPN_EXPECTED_ERROR_CODES,
+                )
             except Exception as err:
                 _LOGGER.debug(
                     "WAN link fetch via %s failed: %s",


### PR DESCRIPTION
## Summary
- treat WAN discovery requests as allowing 400/404 responses without error logging
- keep probing behaviour unchanged while preventing noisy controller error logs

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d0676b415c8327a737324e3430eedd