### PR TITLE
Fix VPN API probes to use v2 endpoints

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -1216,12 +1216,11 @@ class UniFiOSClient:
         total_candidates = 0
 
         def _fetch_vpn_payload(path: str) -> Any:
-            if self._vpn_is_internet_path(path):
-                return self._vpn_get_internet(
-                    path,
-                    expected_errors=_VPN_EXPECTED_ERROR_CODES,
-                )
-            return self._get(path, expected_errors=_VPN_EXPECTED_ERROR_CODES)
+            return self._vpn_api_request(
+                "GET",
+                path,
+                expected_errors=_VPN_EXPECTED_ERROR_CODES,
+            )
 
         def _store_peer(record: Dict[str, Any]) -> None:
             peer_id = record.get("_ha_peer_id") or vpn_peer_identity(record)
@@ -1377,16 +1376,11 @@ class UniFiOSClient:
 
         for path in legacy_paths:
             try:
-                if self._vpn_is_internet_path(path):
-                    payload = self._vpn_get_internet(
-                        path,
-                        expected_errors=_VPN_EXPECTED_ERROR_CODES,
-                    )
-                else:
-                    payload = self._get(
-                        path,
-                        expected_errors=_VPN_EXPECTED_ERROR_CODES,
-                    )
+                payload = self._vpn_api_request(
+                    "GET",
+                    path,
+                    expected_errors=_VPN_EXPECTED_ERROR_CODES,
+                )
             except APIError as err:
                 _LOGGER.debug(
                     "Legacy VPN probe %s failed: %s",


### PR DESCRIPTION
## Summary
- route all VPN API probes through the version-aware request helper so controllers that only expose v2 endpoints are supported
- update legacy VPN discovery to use the same fallback-aware request logic

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d0e73eb25c8327bb450f3d1c8592ec