### PR TITLE
Adjust alert fallback logging for expected 404

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -984,7 +984,13 @@ class UniFiOSClient:
                 return alerts
 
         if last_error is not None:
-            _LOGGER.warning(
+            log_method = _LOGGER.warning
+            if getattr(last_error, "expected", False) or (
+                last_error.status_code in (400, 404)
+            ):
+                log_method = _LOGGER.debug
+
+            log_method(
                 "Fetching %s failed (%s); attempting legacy list/alarm endpoint",
                 path,
                 last_error,


### PR DESCRIPTION
## Summary
- treat 400/404 responses from the v2 list/alert endpoint as expected when the controller only exposes the legacy API
- lower the log level for the fallback message so Home Assistant is not flooded with warning entries in that case

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d10f0c962483279e67f0913c052dd6