### PR TITLE
Improve WAN health fallback and VPN icon consistency

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -84,6 +84,11 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                 health_by_subsystem[subsystem] = record
             if subsystem in {"wan", "www", "internet"}:
                 wan_health.append(record)
+        if not wan_health and health:
+            # Some controllers omit WAN-specific subsystem entries; keep full
+            # health payload as a fallback so sensors can surface something
+            # meaningful instead of reporting missing data entirely.
+            wan_health = list(health)
 
         alerts_raw = self.client.get_alerts() or []
         alerts = [alert for alert in alerts_raw if not alert.get("archived")]

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -1661,7 +1661,7 @@ class UniFiGatewayVpnSiteToSiteSensor(UniFiGatewaySensorBase):
 
     @property
     def icon(self) -> Optional[str]:
-        return _vpn_icon_for_state(self.native_value, self._attr_icon)
+        return _vpn_icon_for_state(self.native_value, self._default_icon)
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- keep the WAN health list populated even when the controller omits WAN-specific subsystem entries
- use the stored default icon when rendering VPN site-to-site sensor state

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d11ac108ec8327928b0543a0f90be7