### PR TITLE
Fix UniFi Gateway identifiers and improve VPN refresh

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -637,7 +637,8 @@ class UniFiOSClient:
         prefix = "/proxy/network" if use_proxy_prefix else ""
         self._base = f"https://{host}:{port}{prefix}/api/s/{site_id}"
 
-        basis = f"{self._base}|{host}|{site_id}|{instance_hint or ''}"
+        # Stable instance identifier should not depend on autodetected base URL.
+        basis = instance_hint or f"{host}|{site_id}"
         self._iid = hashlib.sha1(basis.encode()).hexdigest()[:12]
 
         self._csrf: Optional[str] = None


### PR DESCRIPTION
## Summary
- stabilize the UniFi client instance key using the config entry hint so entity IDs remain consistent across base URL autodetection
- force VPN data fetching during coordinator updates and preserve diagnostics details for sensors
- derive WAN sensor unique IDs from stable identifier candidates to prevent duplicate entities

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d129b0e0448327b32516ec95001402