### PR TITLE
Ensure UniFi client uses entry instance hint

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -53,7 +53,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_USE_PROXY_PREFIX, DEFAULT_USE_PROXY_PREFIX
         ),
         "timeout": entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-        "instance_hint": entry.entry_id,  # stabilizes entity unique_ids across base changes
     }
 
     username = entry.data.get(CONF_USERNAME)
@@ -62,6 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client_kwargs["username"] = username
     if password:
         client_kwargs["password"] = password
+
+    client_kwargs["instance_hint"] = entry.entry_id
 
     client_factory = partial(UniFiOSClient, **client_kwargs)
 


### PR DESCRIPTION
## Summary
- ensure the UniFi client setup always injects the config entry ID as the instance hint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d16cf04dec8327bf8552c0a4f83398