### PR TITLE
Improve VPN peer diagnostics and entity creation

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -14,7 +14,10 @@
   ],
   "integration_type": "hub",
   "loggers": [
-    "custom_components.unifi_gateway_refactored"
+    "custom_components.unifi_gateway_refactored",
+    "custom_components.unifi_gateway_refactored.sensor",
+    "custom_components.unifi_gateway_refactored.coordinator",
+    "custom_components.unifi_gateway_refactored.unifi_client"
   ],
   "logo": "logo.svg",
   "icon": "icon.svg"

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -342,15 +342,13 @@ async def async_setup_entry(
         vpn_servers = coordinator_data.vpn_servers
         vpn_clients = coordinator_data.vpn_clients
         vpn_site_to_site = getattr(coordinator_data, "vpn_site_to_site", [])
-        vpn_summary = {
-            "servers": len(vpn_servers),
-            "clients": len(vpn_clients),
-            "site_to_site": len(vpn_site_to_site),
-        }
+        diagnostics = getattr(coordinator_data, "vpn_diagnostics", {}) or {}
         _LOGGER.debug(
-            "VPN dataset for entry %s: %s",
-            entry.entry_id,
-            vpn_summary,
+            "VPN dataset: servers=%d clients=%d site_to_site=%d diag=%s",
+            len(vpn_servers),
+            len(vpn_clients),
+            len(vpn_site_to_site),
+            diagnostics,
         )
         if not (vpn_servers or vpn_clients or vpn_site_to_site):
             _LOGGER.info(
@@ -358,7 +356,6 @@ async def async_setup_entry(
                 entry.entry_id,
                 getattr(coordinator_data, "vpn_diagnostics", None),
             )
-        diagnostics = getattr(coordinator_data, "vpn_diagnostics", None)
         if diagnostics:
             _LOGGER.debug(
                 "VPN diagnostics for entry %s: %s",


### PR DESCRIPTION
## Summary
- force the coordinator to refresh VPN peers without cache, capture diagnostics, and log warnings when no tunnels are returned
- enhance dynamic sensor setup with detailed VPN dataset logging and reuse cached IDs to avoid duplicate WAN/LAN/WLAN entities
- update the UniFi client to expose reusable peer filters, emit cache/probe logs, and register dedicated loggers for easier debugging

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d17bfbf6288327a5f9b6cdb55b5bb9