### PR TITLE
feat(vpn): widen API probes, rich diagnostics, stable instance key

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ The generated release contains the complete repository (including the
 `custom_components` directory) as required by the
 [HACS publishing guide](https://hacs.xyz/docs/publish/).
 
+## Enable verbose logging
+
+To collect detailed diagnostics (including VPN probe information), add the
+following snippet to your Home Assistant `configuration.yaml` and reload the
+logger integration:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.unifi_gateway_refactored: debug
+    custom_components.unifi_gateway_refactored.unifi_client: debug
+    custom_components.unifi_gateway_refactored.coordinator: debug
+```
+


### PR DESCRIPTION
## Summary
- derive the UniFi client instance key from the config entry hint, emit warning logs with HTTP snippets, and expand the VPN probe endpoint list
- surface VPN diagnostics and error summaries through the coordinator and sensors, including warning when dynamic entity creation fails
- document how to enable verbose logging for the integration

## Testing
- python -m compileall custom_components/unifi_gateway_refactored


------
https://chatgpt.com/codex/tasks/task_b_68d19ab067a88327a029ca374c906ea4