### PR TITLE
Refactor VPN discovery and expose per-connection sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ fully UI-driven configuration flow.
 - **Live validation on save**: during setup we log in and read `/stat/health` and `/self/sites`.
 - **Options Flow**: you can change host/credentials/site/etc. later from the integration's Options.
 - **Diagnostics**: menu "Download diagnostics" dumps controller URL, current site, health, sites.
+- **Per-connection VPN metrics**: remote-access users, site-to-site peers, and Teleport
+  servers/clients are discovered across UniFi Network API generations with per-entity sensors
+  and aggregated diagnostics.
 
 Authentication uses a local **username/password** (the same approach as in
 [`sirkirby/unifi-network-rules`](https://github.com/sirkirby/unifi-network-rules)).
@@ -55,4 +58,8 @@ logger:
     custom_components.unifi_gateway_refactored.unifi_client: debug
     custom_components.unifi_gateway_refactored.coordinator: debug
 ```
+
+When debug logging is enabled the integration records each UniFi Network HTTP request
+and, for non-2xx responses, includes a sanitized preview of the response body (first 1 kB)
+to simplify troubleshooting endpoint discovery issues.
 

--- a/tests/fixtures/error_404.json
+++ b/tests/fixtures/error_404.json
@@ -1,0 +1,3 @@
+{
+  "error": "Not Found"
+}

--- a/tests/fixtures/legacy_remote_user.json
+++ b/tests/fixtures/legacy_remote_user.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "_id": "user1",
+      "username": "alice",
+      "connected": true,
+      "rx_bytes": 1024,
+      "tx_bytes": 2048,
+      "remote_ip": "198.51.100.10"
+    }
+  ]
+}

--- a/tests/fixtures/v1_s2s_peers.json
+++ b/tests/fixtures/v1_s2s_peers.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    {
+      "id": "peer-1",
+      "name": "HQ",
+      "state": "CONNECTED",
+      "rx_bytes": 512,
+      "tx_bytes": 256,
+      "peer_addr": "203.0.113.1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a normalized UniFi Network URL builder with asynchronous VPN endpoint discovery, caching and detailed diagnostics logging
- expose per-connection VPN sensors and diagnostics via the coordinator with deterministic unique IDs and migrations for legacy entities
- document logging behaviour, add VPN fixtures and update tests to validate endpoint probing/normalization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1b87eb85c8327b45a344819336eab