### PR TITLE
Handle restored health sensors for matching config entry

### DIFF
--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -59,12 +59,12 @@ def _build_health_entities(
             entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
             if entity_id:
                 entry_record = ent_reg.async_get(entity_id)
-                if (
-                    entry_record
-                    and getattr(entry_record, "config_entry_id", None)
-                    != entry.entry_id
-                ):
-                    continue
+                if entry_record is not None:
+                    registry_owner = getattr(
+                        entry_record, "config_entry_id", entry.entry_id
+                    )
+                    if registry_owner != entry.entry_id:
+                        continue
             entity = HealthSensor(
                 unique_id=uid,
                 name=subsystem.upper(),


### PR DESCRIPTION
## Summary
- ensure `_build_health_entities` reuses entity registry entries when the config entry matches
- extend health sensor tests with a restart scenario that verifies the sensor is recreated for the same config entry

## Testing
- pytest tests/test_sensor_health.py

------
https://chatgpt.com/codex/tasks/task_b_68d299fc3afc8327bc78d2a88b041ef7