### PR TITLE
Implement legacy VPN overview aggregation and stable unique IDs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,8 @@
-## Summary
-- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
-- [ ] No per-connection VPN entities created.
-- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
-- [ ] Handles 400/404 without raising; diagnostics populated.
-- [ ] No secrets in logs or attributes; redaction verified.
-- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
-- [ ] TLS verify on by default; timeouts finite; retries bounded.
-- [ ] Unique IDs stable and include `entry.entry_id`.
-- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
-- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
+## Checklist
+
+- [ ] No calls to /v2/api/.../internet/vpn/*, /stat/teleport*, /openapi.json, /api-docs
+- [ ] `_join_api` used for all UniFi URLs
+- [ ] No duplicate entities; stable `unique_id` scheme
+- [ ] No secrets in logs; timeouts set; SSL verify respected
+- [ ] Coordinator never raises on VPN 4xx/400
+- [ ] Tests (rg checks) pass

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -52,35 +52,43 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
         site = client.get_site()
 
         try:
-            vpn_state = await self.hass.async_add_executor_job(
-                client.get_vpn_summary,
+            overview = await self.hass.async_add_executor_job(
+                client.get_vpn_overview,
                 site,
             )
         except Exception as err:  # pragma: no cover - defensive guard
             message = str(err)
             _LOGGER.debug(
-                "Fetching VPN summary failed: %s",
+                "Fetching VPN overview failed: %s",
                 err,
                 exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
             )
-            vpn_state = VpnState(errors={"summary": message[:200]})
+            vpn_state = VpnState(errors=[message[:200]])
+        else:
+            if isinstance(overview, dict):
+                vpn_state = VpnState.from_overview(overview)
+            else:
+                vpn_state = VpnState(
+                    errors=[
+                        f"Unexpected VPN overview payload type: {type(overview).__name__}"
+                    ]
+                )
 
-        counts = {
-            "remote_users": len(vpn_state.remote_users),
-            "s2s_peers": len(vpn_state.site_to_site_peers),
-            "teleport_servers": len(vpn_state.teleport_servers),
-            "teleport_clients": len(vpn_state.teleport_clients),
-        }
+        remote_count = int(vpn_state.counts.get("remote_users", 0))
+        s2s_count = int(vpn_state.counts.get("s2s_peers", 0))
+        peers_total = remote_count + s2s_count
 
-        peers_total = sum(counts.values())
         if peers_total:
             _LOGGER.info(
-                "VPN overview discovered: remote_users=%d site_to_site=%d teleport_clients=%d teleport_servers=%d",
-                counts["remote_users"],
-                counts["s2s_peers"],
-                counts["teleport_clients"],
-                counts["teleport_servers"],
+                "VPN overview discovered: remote_users=%d site_to_site=%d configured_list=%s",
+                remote_count,
+                s2s_count,
+                vpn_state.configured_list or "",
             )
+        elif vpn_state.attempts and all(
+            attempt.status in (400, 404) for attempt in vpn_state.attempts
+        ):
+            _LOGGER.debug("VPN state returned no connections for site %s", site)
         else:
             _LOGGER.info("VPN overview contains no entries for site %s", site)
 

--- a/tests/test_sensor_health.py
+++ b/tests/test_sensor_health.py
@@ -87,7 +87,7 @@ def test_build_health_entities_recreates_sensor_for_same_entry(
         created_unique_ids=created_unique_ids,
     )
 
-    uid = f"{config_entry.entry_id}|site|health::{sensor._sanitize_stable_key('www')}"
+    uid = f"{config_entry.entry_id}|site|health|{sensor._sanitize_stable_key('www')}"
     assert registry.requested_unique_ids == [uid]
     assert len(created) == 1
     assert uid in health_entities
@@ -117,7 +117,7 @@ def test_build_health_entities_restores_sensor_after_restart(
         created_unique_ids=created_unique_ids,
     )
 
-    uid = f"{config_entry.entry_id}|site|health::{sensor._sanitize_stable_key('www')}"
+    uid = f"{config_entry.entry_id}|site|health|{sensor._sanitize_stable_key('www')}"
     assert len(first_created) == 1
     assert uid in initial_entities
 

--- a/tests/test_vpn_state.py
+++ b/tests/test_vpn_state.py
@@ -8,16 +8,16 @@ from custom_components.unifi_gateway_refactored.unifi_client import (
 
 def test_vpn_state_mapping_preserves_payload() -> None:
     state = VpnState(
+        counts={"remote_users": 1, "s2s_peers": 1},
+        configured_list="Alice, HQ",
         remote_users=[{"id": "ru1", "name": "Alice"}],
         site_to_site_peers=[{"id": "peer1", "name": "HQ"}],
-        teleport_servers=[{"id": "srv1", "name": "TeleportServer"}],
-        teleport_clients=[{"id": "cl1", "name": "TeleportClient"}],
         attempts=[
             VpnAttempt(
                 path="gateway/health/overview", status=200, ok=True, snippet="{}"
             )
         ],
-        errors={"remote_users": "not available"},
+        errors=["remote users not available"],
     )
 
     data = UniFiGatewayData(controller={}, vpn_state=state)
@@ -25,7 +25,7 @@ def test_vpn_state_mapping_preserves_payload() -> None:
     assert data.vpn_state is state
     assert data.vpn_state.remote_users[0]["name"] == "Alice"
     assert data.vpn_state.attempts[0].path == "gateway/health/overview"
-    assert data.vpn_state.errors["remote_users"] == "not available"
+    assert data.vpn_state.errors[0] == "remote users not available"
 
 
 def test_redact_text_masks_sensitive_tokens() -> None:


### PR DESCRIPTION
## Summary
- add a shared `_join_api` helper, tighten request logging/timeouts, and expose a `get_vpn_overview` that relies on legacy VPN endpoints only
- rework coordinator and sensors to consume the aggregated VPN overview, surface configured lists/attempts, and drop Teleport-specific state
- unify dynamic sensor unique IDs with a stable entry|site|family|metric_key scheme and add a PR checklist template

## Testing
- rg --hidden --line-number "_join_api\("
- rg --hidden --fixed-strings "/v2/api/site/default/internet/vpn" custom_components || true
- rg --hidden --fixed-strings "/stat/teleport" custom_components || true
- rg --hidden --fixed-strings "/openapi.json" custom_components || true
- rg --hidden --fixed-strings "/api-docs" custom_components || true
- rg --hidden --fixed-strings "get_vpn_overview" custom_components
- rg --hidden --fixed-strings "configured_list" custom_components
- rg --hidden --fixed-strings "attempts" custom_components
- rg --hidden --fixed-strings "unique_id" custom_components/unifi_gateway_refactored/sensor.py
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2c507710c8327b784d9bd1e129dbd