### PR TITLE
Fix config flow handler import compatibility

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+
+if TYPE_CHECKING:
+    from homeassistant.data_entry_flow import FlowResult
+else:  # pragma: no cover - fallback for older Home Assistant
+    FlowResult = Dict[str, Any]  # type: ignore[misc, assignment]
 import voluptuous as vol
 
 from .const import (


### PR DESCRIPTION
## Summary
- add a runtime fallback for FlowResult so the config flow can load on older Home Assistant cores without the alias

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2e78b6a6c8327a3e23a237897d86d