### PR TITLE
Fix FlowResult import fallback for config flow

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 import logging
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-
-if TYPE_CHECKING:
+try:  # pragma: no cover - optional import for newer Home Assistant releases
     from homeassistant.data_entry_flow import FlowResult
-else:  # pragma: no cover - fallback for older Home Assistant
+except ImportError:  # pragma: no cover - fallback for older Home Assistant
     FlowResult = Dict[str, Any]  # type: ignore[misc, assignment]
 import voluptuous as vol
 


### PR DESCRIPTION
## Summary
- replace the TYPE_CHECKING guard with a runtime try/except for FlowResult
- ensure older Home Assistant versions fall back to a dict-based FlowResult alias

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d2ea3004548327a06939e370aac18a