### PR TITLE
Restore WWW subsystem sensor

### DIFF
--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -36,6 +36,7 @@ SUBSYSTEM_SENSORS: Dict[str, tuple[str, str]] = {
     "wan": ("WAN", "mdi:shield-outline"),
     "lan": ("LAN", "mdi:lan"),
     "wlan": ("WLAN", "mdi:wifi"),
+    "www": ("WWW", "mdi:web"),
     "vpn": ("VPN", "mdi:folder-key-network"),
 }
 


### PR DESCRIPTION
## Summary
- add the WWW subsystem back to the static sensor list so health data from the controller is exposed again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2f60e4db88327861d3bdaa82c0d89