### PR TITLE
Fix UniFi client constructor syntax error

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -59,7 +59,7 @@ class UniFiOSClient:
         site_id: str = DEFAULT_SITE,
         ssl_verify: bool = False,
         use_proxy_prefix: bool = True,
-        timeout: int = 10
+        timeout: int = 10,
         instance_hint: str | None = None,
     ):
         self._scheme = "https"


### PR DESCRIPTION
## Summary
- add missing comma between the timeout and instance_hint parameters in the UniFi client constructor to restore valid syntax

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d2ff462ba0832799c03b0f2b7123e5