### PR TITLE
Handle missing UniFi alert endpoint gracefully

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -375,7 +375,13 @@ class UniFiOSClient:
         return []
 
     def _get_list(self, path: str, *, timeout: Optional[int] = None) -> List[Dict[str, Any]]:
-        payload = self._request_json("GET", path, timeout=timeout)
+        try:
+            payload = self._request_json("GET", path, timeout=timeout)
+        except APIError as err:
+            if err.expected:
+                LOGGER.debug("UniFi endpoint %s unavailable: %s", path, err)
+                return []
+            raise
         return self._extract_list(payload)
 
     def _post(self, path: str, payload: Dict[str, Any], *, timeout: Optional[int] = None) -> Any:


### PR DESCRIPTION
## Summary
- avoid surfacing errors when optional UniFi endpoints return HTTP 404
- allow the alert polling sequence to fall back to alternative endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d308a67f588327ae64cbe0e5981964