### PR TITLE
Handle 400 responses when probing UniFi WAN endpoints

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -570,7 +570,15 @@ class UniFiOSClient:
             "stat/wan",
             "rest/internet",
         ):
-            links = self._get_list(self._site_path(path))
+            try:
+                links = self._get_list(self._site_path(path))
+            except APIError as err:
+                if err.status_code == 400:
+                    LOGGER.debug(
+                        "UniFi endpoint %s unavailable (HTTP 400): %s", path, err
+                    )
+                    continue
+                raise
             if links:
                 return links
         return []


### PR DESCRIPTION
## Summary
- skip the legacy `/internet/wan` endpoint when the controller responds with HTTP 400
- fall back to the remaining WAN endpoints instead of aborting the refresh

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d30b3ea0bc832793a181884441e5b6