### PR TITLE
Improve VPN endpoint logging and monitoring

### DIFF
--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -209,6 +209,12 @@ async def async_setup_entry(
             entry.entry_id,
         )
         async_add_entities(vpn_entities, update_before_add=True)
+    else:
+        _LOGGER.warning(
+            "UniFi controller for entry %s did not expose any VPN users or peers; "
+            "check controller permissions or VPN configuration",
+            entry.entry_id,
+        )
 
     known_wan: set[str] = set()
     known_lan: set[str] = set()


### PR DESCRIPTION
## Summary
- add warning-level logging with recovery notices for VPN API endpoints to aid troubleshooting
- warn during setup when the controller does not expose any VPN users or peers so operators can adjust configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3e47621e8832784a6676ede34f0c8