### PR TITLE
Add UniFi v2 API fallbacks for WAN and VPN data

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -144,6 +144,14 @@ class UniFiOSClient:
             return f"{base}/{path.lstrip('/')}"
         return base
 
+    def _site_v2_path(self, path: str = "") -> str:
+        """Return the UniFi Network v2 API path for the configured site."""
+
+        base = f"v2/api/site/{self._site_name}".rstrip("/")
+        if path:
+            return f"{base}/{path.lstrip('/')}"
+        return base
+
     def site_name(self) -> str:
         """Return the textual site name used for API requests."""
 
@@ -646,17 +654,30 @@ class UniFiOSClient:
 
     def get_vpn_remote_users(self) -> List[Dict[str, Any]]:
         contexts = (
-            ("list/remoteuser", ("remote_users", "users", "remoteUser")),
-            ("list/vpn", ("remote_users", "remoteUsers", "users", "remote_user")),
+            (
+                self._site_v2_path("vpn/remote-access/users"),
+                ("users", "remote_users", "remoteUsers", "records"),
+            ),
+            (
+                self._site_v2_path("vpn/remote-access/active-users"),
+                ("users", "remote_users", "remoteUsers", "records"),
+            ),
+            (
+                self._site_path("list/remoteuser"),
+                ("remote_users", "users", "remoteUser", "list"),
+            ),
+            (
+                self._site_path("list/vpn"),
+                ("remote_users", "remoteUsers", "users", "remote_user"),
+            ),
         )
-        for path, nested_keys in contexts:
-            api_path = self._site_path(path)
+        for api_path, nested_keys in contexts:
             try:
                 payload = self._get(api_path)
             except APIError as err:
-                self._log_api_error(path, err, context="VPN remote-user")
+                self._log_api_error(api_path, err, context="VPN remote-user")
                 continue
-            self._mark_api_success(path, context="VPN remote-user")
+            self._mark_api_success(api_path, context="VPN remote-user")
             if not payload:
                 continue
             users = self._extract_list(payload)
@@ -668,17 +689,30 @@ class UniFiOSClient:
 
     def get_vpn_peers_status(self) -> List[Dict[str, Any]]:
         contexts = (
-            ("stat/vpn", ("peers", "tunnels", "site_to_site", "vpn_peers")),
-            ("list/vpn", ("peers", "site_to_site", "vpn_peers", "s2s", "s2s_peers")),
+            (
+                self._site_v2_path("vpn/site-to-site/peers"),
+                ("peers", "vpn_peers", "site_to_site", "s2s", "items"),
+            ),
+            (
+                self._site_v2_path("vpn/site-to-site/peer-status"),
+                ("peers", "vpn_peers", "site_to_site", "s2s", "items"),
+            ),
+            (
+                self._site_path("stat/vpn"),
+                ("peers", "tunnels", "site_to_site", "vpn_peers"),
+            ),
+            (
+                self._site_path("list/vpn"),
+                ("peers", "site_to_site", "vpn_peers", "s2s", "s2s_peers"),
+            ),
         )
-        for path, nested_keys in contexts:
-            api_path = self._site_path(path)
+        for api_path, nested_keys in contexts:
             try:
                 payload = self._get(api_path)
             except APIError as err:
-                self._log_api_error(path, err, context="VPN peer")
+                self._log_api_error(api_path, err, context="VPN peer")
                 continue
-            self._mark_api_success(path, context="VPN peer")
+            self._mark_api_success(api_path, context="VPN peer")
             if not payload:
                 continue
             peers = self._extract_list(payload)
@@ -689,18 +723,20 @@ class UniFiOSClient:
         return []
 
     def get_wan_links(self) -> List[Dict[str, Any]]:
-        for path in (
-            "internet/wan",
-            "stat/waninfo",
-            "stat/wan",
-            "rest/internet",
-        ):
+        paths = (
+            self._site_v2_path("internet/wan/links"),
+            self._site_path("internet/wan"),
+            self._site_path("stat/waninfo"),
+            self._site_path("stat/wan"),
+            self._site_path("rest/internet"),
+        )
+        for api_path in paths:
             try:
-                links = self._get_list(self._site_path(path))
+                links = self._get_list(api_path)
             except APIError as err:
                 if err.status_code == 400:
                     LOGGER.debug(
-                        "UniFi endpoint %s unavailable (HTTP 400): %s", path, err
+                        "UniFi endpoint %s unavailable (HTTP 400): %s", api_path, err
                     )
                     continue
                 raise

--- a/tests/test_unifi_client_v2.py
+++ b/tests/test_unifi_client_v2.py
@@ -1,0 +1,111 @@
+"""Tests for UniFiOSClient helpers that integrate with the v2 UniFi APIs."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import List
+
+import pytest
+
+import sys
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "custom_components")
+]
+sys.modules.setdefault("custom_components", custom_components)
+
+ugw_package = types.ModuleType("custom_components.unifi_gateway_refactored")
+ugw_package.__path__ = [
+    str(
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "unifi_gateway_refactored"
+    )
+]
+sys.modules.setdefault("custom_components.unifi_gateway_refactored", ugw_package)
+
+ha_const = types.ModuleType("homeassistant.const")
+ha_const.Platform = type(
+    "Platform",
+    (),
+    {"SENSOR": "sensor", "BINARY_SENSOR": "binary_sensor"},
+)
+sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+sys.modules.setdefault("homeassistant.const", ha_const)
+
+from custom_components.unifi_gateway_refactored.unifi_client import (  # type: ignore  # noqa: E402
+    APIError,
+    UniFiOSClient,
+)
+
+
+def _build_client() -> UniFiOSClient:
+    client = object.__new__(UniFiOSClient)
+    client._site_name = "default"
+    client._api_error_log_state = {}
+    return client
+
+
+def test_get_vpn_remote_users_prefers_v2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure VPN remote users are fetched from the v2 endpoint when available."""
+
+    client = _build_client()
+    calls: List[str] = []
+
+    def _fake_get(path: str, *, timeout: int | None = None) -> dict:
+        calls.append(path)
+        if path.endswith("v2/api/site/default/vpn/remote-access/users"):
+            return {"users": [{"id": "user1"}]}
+        raise APIError("not found", expected=True)
+
+    monkeypatch.setattr(client, "_get", _fake_get)
+
+    users = client.get_vpn_remote_users()
+
+    assert calls[0].endswith("v2/api/site/default/vpn/remote-access/users")
+    assert users == [{"id": "user1"}]
+
+
+def test_get_vpn_peers_status_prefers_v2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure VPN peer status is retrieved from the v2 API when present."""
+
+    client = _build_client()
+    calls: List[str] = []
+
+    def _fake_get(path: str, *, timeout: int | None = None) -> dict:
+        calls.append(path)
+        if path.endswith("v2/api/site/default/vpn/site-to-site/peers"):
+            return {"peers": [{"id": "peer-1"}]}
+        raise APIError("not found", expected=True)
+
+    monkeypatch.setattr(client, "_get", _fake_get)
+
+    peers = client.get_vpn_peers_status()
+
+    assert calls[0].endswith("v2/api/site/default/vpn/site-to-site/peers")
+    assert peers == [{"id": "peer-1"}]
+
+
+def test_get_wan_links_prefers_v2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure WAN links prefer the modern v2 endpoint when available."""
+
+    client = _build_client()
+    calls: List[str] = []
+
+    def _fake_get_list(path: str, *, timeout: int | None = None) -> list:
+        calls.append(path)
+        if path.endswith("v2/api/site/default/internet/wan/links"):
+            return [{"id": "wan"}]
+        return []
+
+    monkeypatch.setattr(client, "_get_list", _fake_get_list)
+
+    links = client.get_wan_links()
+
+    assert calls[0].endswith("v2/api/site/default/internet/wan/links")
+    assert links == [{"id": "wan"}]


### PR DESCRIPTION
## Summary
- add a helper to address UniFi Network v2 API paths
- prefer modern v2 endpoints for WAN links and VPN remote users/peers while retaining legacy fallbacks
- add regression tests that confirm the client uses v2 endpoints when available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3ebb86c6483279ea1452676668e86