### PR TITLE
Fix speedtest metadata and WAN status handling

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -884,13 +884,18 @@ class UniFiOSClient:
                         out[detail_key] = value
                     return
 
-            _assign("server_cc", ["cc"])
-            _assign("server_city", ["city", "name"])
+            _assign("server_id", ["id", "serverid", "server_id"])
+            _assign("server_name", ["name", "server", "label"])
+            _assign("server_city", ["city", "location"])
+            if "server_city" not in out and "server_name" in out:
+                out["server_city"] = out["server_name"]
+            _assign("server_cc", ["cc", "country_code"])
             _assign("server_country", ["country"])
             _assign("server_lat", ["lat", "latitude"], converter=self._coerce_float)
             _assign("server_long", ["long", "lon", "lng"], converter=self._coerce_float)
             _assign("server_provider", ["provider", "sponsor"])
             _assign("server_provider_url", ["provider_url", "url"])
+            _assign("server_host", ["host", "hostname", "fqdn"])
         if "status" in rec:
             status_value = rec["status"]
             if isinstance(status_value, dict):


### PR DESCRIPTION
## Summary
- format speedtest run timestamps to 24-hour local time, include raw values, and expose additional server metadata (id, name, host)
- normalize WAN status using link and health sources, format last_update to 24-hour local time, and track the status source
- surface aggregated user totals across subsystem sensors

## Testing
- python -m compileall custom_components
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d410b0c6808327ad46267a97670023