### PR TITLE
Fix persistent_notification import path

### DIFF
--- a/custom_components/unifi_gateway_refactored/monitor.py
+++ b/custom_components/unifi_gateway_refactored/monitor.py
@@ -9,7 +9,7 @@ from typing import Awaitable, Callable, Sequence
 import async_timeout
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import persistent_notification as pn
+from homeassistant.components import persistent_notification as pn
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import (


### PR DESCRIPTION
## Summary
- update persistent notification import to use the supported homeassistant.components entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d4d7db87f0832784e7402667247806