### PR TITLE
Fix UniFi speedtest runner to use controller API

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -179,7 +179,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             trace_id=trace_id,
         )
 
-    runner = SpeedtestRunner(hass, entity_ids, _dispatch_result)
+    runner = SpeedtestRunner(hass, entity_ids, _dispatch_result, client, coordinator)
     entry_data[DATA_RUNNER] = runner
 
     _LOGGER.debug(


### PR DESCRIPTION
## Summary
- update the speedtest runner to execute tests via the UniFi controller API instead of Home Assistant entities
- add polling, status interpretation, and coordinator refresh logic so new results propagate reliably
- pass the UniFi client and coordinator into the speedtest runner during setup

## Testing
- python -m compileall custom_components/unifi_gateway_refactored

------
https://chatgpt.com/codex/tasks/task_b_68d547749b488327ad449d5270e445cf