### PR TITLE
Unify speedtest interval option and rename integration to Dashboard Analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-# UniFi Gateway (Refactored)
+# UniFi Gateway Dashboard Analyzer
 
 Custom integration for Home Assistant that exposes UniFi Gateway metrics with a
 fully UI-driven configuration flow.
 
 ## Features
 
-- **UI-based setup** (no YAML): Add Integration → UniFi Gateway (Refactored).
+- **UI-based setup** (no YAML): Add Integration → UniFi Gateway Dashboard Analyzer.
 - **Live validation on save**: during setup we log in and read `/stat/health` and `/self/sites`.
 - **Options Flow**: you can change host/credentials/site/etc. later from the integration's Options.
 - **Diagnostics**: menu "Download diagnostics" dumps controller URL, current site, health, sites.

--- a/custom_components/unifi_gateway_refactored/button.py
+++ b/custom_components/unifi_gateway_refactored/button.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     device_name = entry_data.get("device_name") or entry.title or "UniFi Gateway"
     if client is None:
         raise RuntimeError(
-            "UniFi Gateway Refactored client missing during button setup"
+            "UniFi Gateway Dashboard Analyzer client missing during button setup"
         )
     async_add_entities(
         [SpeedtestRunButton(hass, entry, client, device_name)], True

--- a/custom_components/unifi_gateway_refactored/const.py
+++ b/custom_components/unifi_gateway_refactored/const.py
@@ -14,7 +14,8 @@ CONF_VERIFY_SSL = "verify_ssl"
 CONF_USE_PROXY_PREFIX = "use_proxy_prefix"
 CONF_TIMEOUT = "timeout"
 CONF_SPEEDTEST_INTERVAL = "speedtest_interval"
-CONF_SPEEDTEST_INTERVAL_MIN = "speedtest_interval_minutes"
+# Legacy option key kept for backwards compatibility with pre-0.6.1 releases
+LEGACY_CONF_SPEEDTEST_INTERVAL_MIN = "speedtest_interval_minutes"
 CONF_SPEEDTEST_ENTITIES = "speedtest_entities"
 
 DEFAULT_PORT = 443
@@ -22,8 +23,8 @@ DEFAULT_SITE = "default"
 DEFAULT_VERIFY_SSL = False
 DEFAULT_USE_PROXY_PREFIX = True
 DEFAULT_TIMEOUT = 10
-DEFAULT_SPEEDTEST_INTERVAL = 3600
-DEFAULT_SPEEDTEST_INTERVAL_MIN = 60
+DEFAULT_SPEEDTEST_INTERVAL = 3600  # seconds
+DEFAULT_SPEEDTEST_INTERVAL_MINUTES = 60
 DEFAULT_SPEEDTEST_ENTITIES = (
     "sensor.speedtest_download,sensor.speedtest_upload,sensor.speedtest_ping"
 )

--- a/custom_components/unifi_gateway_refactored/icon.svg
+++ b/custom_components/unifi_gateway_refactored/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
-  <title>UniFi Gateway Refactored Icon</title>
+  <title>UniFi Gateway Dashboard Analyzer Icon</title>
   <defs>
     <linearGradient id="icon-grad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#1f9dd1"/>

--- a/custom_components/unifi_gateway_refactored/logo.svg
+++ b/custom_components/unifi_gateway_refactored/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title>UniFi Gateway Refactored Logo</title>
+  <title>UniFi Gateway Dashboard Analyzer Logo</title>
   <desc>Stylised gateway shield with wireless waves.</desc>
   <defs>
     <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/custom_components/unifi_gateway_refactored/strings.json
+++ b/custom_components/unifi_gateway_refactored/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to UniFi Gateway",
+        "title": "Connect to UniFi Gateway Dashboard Analyzer",
         "description": "Enter local admin credentials for the UniFi Network Application. We'll validate by fetching health and sites.",
         "data": {
           "host": "Host (UDM IP)",
@@ -20,7 +20,6 @@
           "use_proxy_prefix": "Use /proxy/network prefix",
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
-          "speedtest_interval_minutes": "Speedtest runner interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)"
         }
       }
@@ -35,7 +34,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "UniFi Gateway Options",
+        "title": "UniFi Gateway Dashboard Analyzer Options",
         "description": "Update the connection details or advanced controller settings.",
         "data": {
           "host": "Host (UDM IP)",
@@ -47,7 +46,6 @@
           "use_proxy_prefix": "Use /proxy/network prefix",
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
-          "speedtest_interval_minutes": "Speedtest runner interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)"
         }
       }
@@ -59,5 +57,5 @@
       "unknown": "Unknown error."
     }
   },
-  "title": "UniFi Gateway (Refactored)"
+  "title": "UniFi Gateway Dashboard Analyzer"
 }

--- a/custom_components/unifi_gateway_refactored/translations/en.json
+++ b/custom_components/unifi_gateway_refactored/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to UniFi Gateway",
+        "title": "Connect to UniFi Gateway Dashboard Analyzer",
         "description": "Enter local admin credentials for the UniFi Network Application. We'll validate by fetching health and sites.",
         "data": {
           "host": "Host (UDM IP)",
@@ -20,7 +20,6 @@
           "use_proxy_prefix": "Use /proxy/network prefix",
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
-          "speedtest_interval_minutes": "Speedtest runner interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)"
         }
       }
@@ -35,7 +34,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "UniFi Gateway Options",
+        "title": "UniFi Gateway Dashboard Analyzer Options",
         "description": "Update the connection details or advanced controller settings.",
         "data": {
           "host": "Host (UDM IP)",
@@ -47,7 +46,6 @@
           "use_proxy_prefix": "Use /proxy/network prefix",
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
-          "speedtest_interval_minutes": "Speedtest runner interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)"
         }
       }
@@ -59,5 +57,5 @@
       "unknown": "Unknown error."
     }
   },
-  "title": "UniFi Gateway (Refactored)"
+  "title": "UniFi Gateway Dashboard Analyzer"
 }

--- a/custom_components/unifi_gateway_refactored/translations/pl.json
+++ b/custom_components/unifi_gateway_refactored/translations/pl.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Połącz z UniFi Gateway",
+        "title": "Połącz z UniFi Gateway Dashboard Analyzer",
         "description": "Wprowadź dane lokalnego administratora aplikacji UniFi Network. Podczas zapisu sprawdzimy zdrowie kontrolera i listę witryn.",
         "data": {
           "host": "Adres kontrolera (UDM IP)",
@@ -20,7 +20,6 @@
           "use_proxy_prefix": "Użyj prefiksu /proxy/network",
           "timeout": "Limit czasu żądania HTTP (sekundy)",
           "speedtest_interval": "Interwał speedtestu (minuty)",
-          "speedtest_interval_minutes": "Interwał uruchamiania speedtestu (minuty)",
           "speedtest_entities": "Identyfikatory encji speedtestu (oddzielone przecinkami)"
         }
       }
@@ -34,7 +33,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Opcje UniFi Gateway",
+        "title": "Opcje UniFi Gateway Dashboard Analyzer",
         "description": "Zaktualizuj szczegóły połączenia lub ustawienia zaawansowane kontrolera.",
         "data": {
           "host": "Adres kontrolera (UDM IP)",
@@ -46,7 +45,6 @@
           "use_proxy_prefix": "Użyj prefiksu /proxy/network",
           "timeout": "Limit czasu żądania HTTP (sekundy)",
           "speedtest_interval": "Interwał speedtestu (minuty)",
-          "speedtest_interval_minutes": "Interwał uruchamiania speedtestu (minuty)",
           "speedtest_entities": "Identyfikatory encji speedtestu (oddzielone przecinkami)"
         }
       }
@@ -57,5 +55,5 @@
       "unknown": "Nieznany błąd."
     }
   },
-  "title": "UniFi Gateway (Refactored)"
+  "title": "UniFi Gateway Dashboard Analyzer"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "UniFi Gateway (Refactored)",
+  "name": "UniFi Gateway Dashboard Analyzer",
   "render_readme": true,
   "logo": "images/logo.svg",
   "icon": "images/icon.svg"

--- a/images/icon.svg
+++ b/images/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
-  <title>UniFi Gateway Refactored Icon</title>
+  <title>UniFi Gateway Dashboard Analyzer Icon</title>
   <defs>
     <linearGradient id="icon-grad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#1f9dd1"/>

--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title>UniFi Gateway Refactored Logo</title>
+  <title>UniFi Gateway Dashboard Analyzer Logo</title>
   <desc>Stylised gateway shield with wireless waves.</desc>
   <defs>
     <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">


### PR DESCRIPTION
## Summary
- merge the redundant speedtest interval settings into a single minutes option while keeping legacy data compatible
- rename the integration, documentation, and assets to UniFi Gateway Dashboard Analyzer and bump the manifest to v0.6.1
- refresh translations and metadata to match the new naming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8d23db78c832784fdb6fec8990010