### PR TITLE
Fix speedtest button unique IDs, normalize entity configuration, and honor legacy intervals

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -5,7 +5,8 @@ import hashlib
 import logging
 from datetime import timedelta
 from functools import partial
-from typing import Any, TYPE_CHECKING
+from collections.abc import Mapping
+from typing import Any, Iterable, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from homeassistant.config_entries import ConfigEntry
@@ -45,6 +46,95 @@ from .monitor import SpeedtestRunner
 _LOGGER = logging.getLogger(__name__)
 
 
+def _split_entity_candidates(text: str) -> Iterable[str]:
+    for candidate in text.replace("\n", ",").split(","):
+        cleaned = candidate.strip()
+        if cleaned:
+            yield cleaned
+
+
+_DEFAULT_SPEEDTEST_ENTITY_IDS: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        candidate
+        for raw in DEFAULT_SPEEDTEST_ENTITIES
+        for candidate in _split_entity_candidates(str(raw))
+    )
+) or (
+    "sensor.speedtest_download",
+    "sensor.speedtest_upload",
+    "sensor.speedtest_ping",
+)
+
+
+def _normalize_speedtest_entity_ids(raw: Any) -> list[str]:
+    """Normalize speedtest entity identifiers from options/data into a stable list."""
+
+    normalized: dict[str, None] = {}
+
+    def _add_from_text(text: str) -> None:
+        for candidate in _split_entity_candidates(text):
+            if candidate not in normalized:
+                normalized[candidate] = None
+
+    if isinstance(raw, str):
+        _add_from_text(raw)
+    elif isinstance(raw, (list, tuple, set)):
+        for candidate in raw:
+            if isinstance(candidate, str):
+                _add_from_text(candidate)
+            elif candidate is not None:
+                text = str(candidate).strip()
+                if text:
+                    if text not in normalized:
+                        normalized[text] = None
+
+    if not normalized:
+        return list(_DEFAULT_SPEEDTEST_ENTITY_IDS)
+
+    return list(normalized)
+
+
+def _resolve_speedtest_interval_seconds(
+    options: Mapping[str, Any], data: Mapping[str, Any]
+) -> int:
+    """Determine the configured speedtest interval in seconds with legacy support."""
+
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    speedtest_interval_seconds: int | None = None
+    for source in (options, data):
+        candidate = _coerce_int(source.get(CONF_SPEEDTEST_INTERVAL))
+        if candidate is not None:
+            speedtest_interval_seconds = candidate
+            break
+
+    legacy_minutes: int | None = None
+    for source in (options, data):
+        candidate = _coerce_int(source.get(LEGACY_CONF_SPEEDTEST_INTERVAL_MIN))
+        if candidate is not None:
+            legacy_minutes = candidate
+            break
+
+    if legacy_minutes is not None:
+        legacy_seconds = max(0, legacy_minutes) * 60
+        if (
+            legacy_minutes != DEFAULT_SPEEDTEST_INTERVAL_MINUTES
+            or speedtest_interval_seconds is None
+        ):
+            speedtest_interval_seconds = legacy_seconds
+
+    if speedtest_interval_seconds is None:
+        speedtest_interval_seconds = DEFAULT_SPEEDTEST_INTERVAL
+
+    return max(0, speedtest_interval_seconds)
+
+
 async def async_setup(hass: "HomeAssistant", config: "ConfigType") -> bool:
     """Set up the UniFi Gateway Dashboard Analyzer component."""
     _LOGGER.debug("Setting up UniFi Gateway Dashboard Analyzer integration")
@@ -82,33 +172,7 @@ async def async_setup_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> bool
 
     options = entry.options or {}
 
-    def _coerce_int(value: Any) -> int | None:
-        try:
-            if value is None:
-                return None
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-
-    speedtest_interval_seconds: int | None = None
-    for source in (options, entry.data):
-        speedtest_interval_seconds = _coerce_int(source.get(CONF_SPEEDTEST_INTERVAL))
-        if speedtest_interval_seconds is not None:
-            break
-
-    if speedtest_interval_seconds is None:
-        legacy_minutes: int | None = None
-        for source in (options, entry.data):
-            legacy_minutes = _coerce_int(source.get(LEGACY_CONF_SPEEDTEST_INTERVAL_MIN))
-            if legacy_minutes is not None:
-                break
-        if legacy_minutes is not None:
-            speedtest_interval_seconds = max(0, legacy_minutes) * 60
-
-    if speedtest_interval_seconds is None:
-        speedtest_interval_seconds = DEFAULT_SPEEDTEST_INTERVAL
-    else:
-        speedtest_interval_seconds = max(0, speedtest_interval_seconds)
+    speedtest_interval_seconds = _resolve_speedtest_interval_seconds(options, entry.data)
 
     try:
         client: UniFiOSClient = await hass.async_add_executor_job(client_factory)
@@ -135,21 +199,7 @@ async def async_setup_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> bool
         interval_minutes = max(5, round(speedtest_interval_seconds / 60))
 
     raw_entities = options.get(CONF_SPEEDTEST_ENTITIES, DEFAULT_SPEEDTEST_ENTITIES)
-    entity_ids: list[str] = []
-    if isinstance(raw_entities, str):
-        candidates = raw_entities.replace("\n", ",").split(",")
-        entity_ids = [candidate.strip() for candidate in candidates if candidate.strip()]
-    elif isinstance(raw_entities, (list, tuple, set)):
-        for candidate in raw_entities:
-            text = str(candidate).strip()
-            if text:
-                entity_ids.append(text)
-    if not entity_ids:
-        entity_ids = [
-            candidate.strip()
-            for candidate in DEFAULT_SPEEDTEST_ENTITIES.split(",")
-            if candidate.strip()
-        ]
+    entity_ids = _normalize_speedtest_entity_ids(raw_entities)
 
     async def _noop_result_callback(
         *, success: bool, duration_ms: int, error: str | None, trace_id: str
@@ -194,6 +244,7 @@ async def async_setup_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> bool
         entry.entry_id,
     )
 
+    await _async_migrate_speedtest_button_unique_id(hass, entry)
     await _async_migrate_interface_unique_ids(hass, entry, client, coordinator.data)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -237,6 +288,44 @@ async def async_unload_entry(hass: "HomeAssistant", entry: "ConfigEntry") -> boo
             "UniFi Gateway Dashboard Analyzer entry %s unloaded", entry.entry_id
         )
     return unload_ok
+
+
+async def _async_migrate_speedtest_button_unique_id(
+    hass: "HomeAssistant", entry: "ConfigEntry"
+) -> None:
+    """Ensure the Run Speedtest button unique ID is namespaced per config entry."""
+
+    from homeassistant.helpers import entity_registry as er
+
+    try:
+        from .utils import build_speedtest_button_unique_id
+    except ImportError:  # pragma: no cover - defensive guard
+        return
+
+    registry = er.async_get(hass)
+    old_unique_id = "unifi_gateway_refactored_run_speedtest"
+    new_unique_id = build_speedtest_button_unique_id(entry.entry_id)
+
+    if old_unique_id == new_unique_id:
+        return
+
+    migrated = False
+
+    async def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+        nonlocal migrated
+        if entity_entry.config_entry_id != entry.entry_id:
+            return None
+        if entity_entry.unique_id != old_unique_id:
+            return None
+        migrated = True
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, DOMAIN, _migrate)
+
+    if migrated:
+        _LOGGER.info(
+            "Migrated Run Speedtest button unique ID for entry %s", entry.entry_id
+        )
 
 
 async def _async_migrate_interface_unique_ids(

--- a/custom_components/unifi_gateway_refactored/monitor.py
+++ b/custom_components/unifi_gateway_refactored/monitor.py
@@ -44,11 +44,24 @@ class SpeedtestRunner:
         coordinator: UniFiGatewayDataUpdateCoordinator,
     ) -> None:
         self.hass = hass
-        self.entity_ids = [entity_id for entity_id in entity_ids if entity_id]
+        self.entity_ids = self._normalize_entity_ids(entity_ids)
         self._on_result_cb = on_result_cb
         self._client = client
         self._coordinator = coordinator
         self._lock = asyncio.Lock()
+
+    @staticmethod
+    def _normalize_entity_ids(entity_ids: Sequence[str]) -> list[str]:
+        """Return entity IDs stripped of blanks and duplicates while preserving order."""
+
+        normalized: dict[str, None] = {}
+        for candidate in entity_ids:
+            if not candidate:
+                continue
+            text = str(candidate).strip()
+            if text and text not in normalized:
+                normalized[text] = None
+        return list(normalized)
 
     @staticmethod
     def _record_marker(record: dict[str, Any] | None) -> tuple[Any, ...] | None:

--- a/custom_components/unifi_gateway_refactored/utils.py
+++ b/custom_components/unifi_gateway_refactored/utils.py
@@ -1,0 +1,12 @@
+"""Utility helpers for the UniFi Gateway Dashboard Analyzer integration."""
+
+from __future__ import annotations
+
+
+def build_speedtest_button_unique_id(entry_id: str) -> str:
+    """Return a stable unique ID for the Run Speedtest button entity."""
+
+    return f"{entry_id}_run_speedtest"
+
+
+__all__ = ["build_speedtest_button_unique_id"]

--- a/tests/test_init_helpers.py
+++ b/tests/test_init_helpers.py
@@ -1,0 +1,67 @@
+import custom_components.unifi_gateway_refactored as gw_init
+from custom_components.unifi_gateway_refactored.const import (
+    CONF_SPEEDTEST_INTERVAL,
+    DEFAULT_SPEEDTEST_INTERVAL,
+    DEFAULT_SPEEDTEST_INTERVAL_MINUTES,
+    LEGACY_CONF_SPEEDTEST_INTERVAL_MIN,
+)
+from custom_components.unifi_gateway_refactored.utils import (
+    build_speedtest_button_unique_id,
+)
+from custom_components.unifi_gateway_refactored.monitor import SpeedtestRunner
+
+
+def test_normalize_speedtest_entity_ids_from_string():
+    raw = " sensor.one ,sensor.two\n,sensor.one,,"
+    result = gw_init._normalize_speedtest_entity_ids(raw)
+    assert result == ["sensor.one", "sensor.two"]
+
+
+def test_normalize_speedtest_entity_ids_from_iterable():
+    raw = ["sensor.one", "  sensor.two  ", "sensor.one", "sensor.three", None, ""]
+    result = gw_init._normalize_speedtest_entity_ids(raw)
+    assert result == ["sensor.one", "sensor.two", "sensor.three"]
+
+
+def test_normalize_speedtest_entity_ids_fallback():
+    result = gw_init._normalize_speedtest_entity_ids(object())
+    assert result == list(gw_init._DEFAULT_SPEEDTEST_ENTITY_IDS)
+
+
+def test_build_speedtest_button_unique_id_namespaced():
+    assert build_speedtest_button_unique_id("entry123") == "entry123_run_speedtest"
+
+
+def test_speedtest_runner_normalizes_entity_ids():
+    source = ["sensor.one", " sensor.one ", "sensor.two", "", None, "sensor.two"]
+    assert SpeedtestRunner._normalize_entity_ids(source) == [
+        "sensor.one",
+        "sensor.two",
+    ]
+
+
+def test_resolve_speedtest_interval_prefers_legacy_minutes_when_custom():
+    options = {LEGACY_CONF_SPEEDTEST_INTERVAL_MIN: 15}
+    data = {CONF_SPEEDTEST_INTERVAL: DEFAULT_SPEEDTEST_INTERVAL}
+
+    assert (
+        gw_init._resolve_speedtest_interval_seconds(options, data)
+        == 15 * 60
+    )
+
+
+def test_resolve_speedtest_interval_uses_seconds_when_minutes_default():
+    options = {CONF_SPEEDTEST_INTERVAL: 1800}
+    data = {LEGACY_CONF_SPEEDTEST_INTERVAL_MIN: DEFAULT_SPEEDTEST_INTERVAL_MINUTES}
+
+    assert gw_init._resolve_speedtest_interval_seconds(options, data) == 1800
+
+
+def test_resolve_speedtest_interval_defaults_when_missing():
+    options = {}
+    data = {}
+
+    assert (
+        gw_init._resolve_speedtest_interval_seconds(options, data)
+        == DEFAULT_SPEEDTEST_INTERVAL
+    )


### PR DESCRIPTION
## Summary
- ensure the Run Speedtest button unique ID is namespaced per config entry and migrate existing entries
- normalize configured speedtest entities and deduplicate monitored entity ids for better robustness
- add helper utilities and unit tests covering the new normalization and unique ID helpers
- preserve legacy minute-based speedtest interval configuration when resolving the runner cadence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8dcbc04e4832783d9a2cda92e867e