### PR TITLE
Add connected client details to VPN sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,78 @@
 Custom integration for Home Assistant that exposes UniFi Gateway metrics with a
 fully UI-driven configuration flow.
 
-## Features
+## Integration guide (English)
 
-- **UI-based setup** (no YAML): Add Integration → UniFi Gateway Dashboard Analyzer.
-- **Live validation on save**: during setup we log in and read `/stat/health` and `/self/sites`.
-- **Options Flow**: you can change host/credentials/site/etc. later from the integration's Options.
-- **Diagnostics**: menu "Download diagnostics" dumps controller URL, current site, health, sites.
+### What this integration does for you
 
-Authentication uses a local **username/password** (the same approach as in
-[`sirkirby/unifi-network-rules`](https://github.com/sirkirby/unifi-network-rules)).
+- Presents WAN, LAN, WLAN and internet health metrics from your UniFi Gateway so
+  you can monitor uptime, throughput and alerts from the Home Assistant
+  dashboard.
+- Tracks firmware status for UniFi devices and highlights upgrades directly in
+  Home Assistant.
+- Creates dedicated VPN server sensors that count active sessions and expose a
+  **Connected Clients** attribute listing each user as
+  `Name ~ Source IP | Internal IP | Source Country | Source City | Source ISP`.
+  No other entity includes that attribute, so you immediately know which card
+  to open when reviewing VPN activity.
+- Provides live diagnostic data (controller URLs, current site, last fetched
+  payloads) that can be shared with support teams when something stops working.
+
+### How to get started
+
+1. In Home Assistant navigate to **Settings → Devices & Services → Add
+   Integration** and search for **UniFi Gateway Dashboard Analyzer**.
+2. Enter the controller address, site and credentials (local UniFi OS username
+   and password). The form validates everything before saving.
+3. After the initial setup you can revisit the entry and use **Configure** to
+   adjust connection details without deleting the integration.
+
+### Daily use tips
+
+- Pin the WAN/LAN/WLAN sensors to a dashboard card to keep latency and alert
+  status in view.
+- Use the VPN server sensor state to trigger automations (for example notify
+  when more than five remote workers are connected).
+- Expand the **Connected Clients** attribute on a VPN sensor to see the device
+  name, public IP origin and geolocation details for every active tunnel.
+- Download **Diagnostics** from the integration's menu whenever you need a
+  snapshot of controller data for troubleshooting.
+
+## Przewodnik integracji (Polski)
+
+### Co daje ta integracja
+
+- Udostępnia w Home Assistant wskaźniki WAN, LAN, WLAN i stanu internetu z
+  bramy UniFi, aby łatwo kontrolować dostępność łącza, przepustowość i alarmy.
+- Śledzi wersje oprogramowania urządzeń UniFi i wskazuje dostępne aktualizacje
+  bezpośrednio w Home Assistant.
+- Tworzy osobne sensory serwerów VPN zliczające aktywne sesje oraz dodające
+  atrybut **Connected Clients** w formacie
+  `Nazwa ~ IP źródłowe | IP wewnętrzne | Kraj | Miasto | ISP`. Żadna inna encja
+  nie pokazuje tego atrybutu, więc przeglądanie aktywności VPN jest proste i
+  szybkie.
+- Umożliwia pobranie diagnostyki (adresy kontrolera, aktualna witryna, ostatnie
+  dane) do przekazania zespołowi wsparcia.
+
+### Jak zacząć
+
+1. W Home Assistant przejdź do **Ustawienia → Urządzenia i usługi → Dodaj
+   integrację** i wyszukaj **UniFi Gateway Dashboard Analyzer**.
+2. Podaj adres kontrolera, witrynę oraz dane logowania (lokalny użytkownik i
+   hasło UniFi OS). Formularz sprawdza poprawność przed zapisaniem.
+3. Po instalacji możesz wybrać **Konfiguruj** przy wpisie integracji, aby w
+   każdej chwili zmienić parametry połączenia.
+
+### Wskazówki do codziennego użycia
+
+- Dodaj sensory WAN/LAN/WLAN na dashboard, aby mieć stale podgląd opóźnień i
+  stanu alarmów.
+- Wykorzystaj stan sensora serwera VPN w automatyzacjach (np. wyślij powiadomienie,
+  gdy liczba zdalnych użytkowników przekroczy pięć).
+- Rozwiń atrybut **Connected Clients** na sensorze VPN, aby zobaczyć nazwę
+  urządzenia, adres publiczny oraz geolokalizację każdego tunelu.
+- W menu integracji wybierz **Pobierz diagnostykę**, aby zebrać migawkę danych do
+  rozwiązywania problemów.
 
 ## Repository layout required by HACS
 

--- a/tests/stubs/homeassistant/components/__init__.py
+++ b/tests/stubs/homeassistant/components/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal stub for homeassistant.components."""

--- a/tests/stubs/homeassistant/components/sensor.py
+++ b/tests/stubs/homeassistant/components/sensor.py
@@ -1,0 +1,23 @@
+"""Minimal stubs for Home Assistant sensor module."""
+
+
+class SensorEntity:
+    """Basic sensor entity stub."""
+
+    _attr_should_poll = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._attr_name = kwargs.get("name")
+
+
+class SensorDeviceClass:
+    """Stub of Home Assistant sensor device classes."""
+
+    TIMESTAMP = "timestamp"
+    DURATION = "duration"
+
+
+class SensorStateClass:
+    """Stub of Home Assistant sensor state classes."""
+
+    MEASUREMENT = "measurement"

--- a/tests/stubs/homeassistant/config_entries.py
+++ b/tests/stubs/homeassistant/config_entries.py
@@ -1,0 +1,16 @@
+"""Stub for homeassistant.config_entries."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class ConfigEntry:
+    """Simplified ConfigEntry."""
+
+    entry_id: str = "test"
+    title: str | None = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = ["ConfigEntry"]

--- a/tests/stubs/homeassistant/const.py
+++ b/tests/stubs/homeassistant/const.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 from enum import Enum
 
 
+class UnitOfTime(Enum):
+    """Minimal UnitOfTime enum stub."""
+
+    MILLISECONDS = "milliseconds"
+
+
+TIME_MILLISECONDS = UnitOfTime.MILLISECONDS
+
+
 class Platform(str, Enum):
     """Subset of Home Assistant platforms referenced by the integration."""
 
@@ -12,4 +21,4 @@ class Platform(str, Enum):
     SENSOR = "sensor"
 
 
-__all__ = ["Platform"]
+__all__ = ["Platform", "UnitOfTime", "TIME_MILLISECONDS"]

--- a/tests/stubs/homeassistant/helpers/__init__.py
+++ b/tests/stubs/homeassistant/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Stub package for homeassistant.helpers."""

--- a/tests/stubs/homeassistant/helpers/entity.py
+++ b/tests/stubs/homeassistant/helpers/entity.py
@@ -1,0 +1,7 @@
+"""Stub for homeassistant.helpers.entity."""
+
+
+class EntityCategory:
+    """Minimal enumeration replacement."""
+
+    DIAGNOSTIC = "diagnostic"

--- a/tests/stubs/homeassistant/helpers/entity_platform.py
+++ b/tests/stubs/homeassistant/helpers/entity_platform.py
@@ -1,0 +1,11 @@
+"""Stub for homeassistant.helpers.entity_platform."""
+
+from typing import Callable, Iterable, Sequence
+
+AddEntitiesCallback = Callable[[Sequence], None]
+
+
+def async_add_entities_callback(entities: Iterable, update_before_add: bool = False) -> None:
+    """Simple helper mirroring Home Assistant signature."""
+    for _ in entities:
+        pass

--- a/tests/stubs/homeassistant/helpers/entity_registry.py
+++ b/tests/stubs/homeassistant/helpers/entity_registry.py
@@ -1,0 +1,27 @@
+"""Stub for homeassistant.helpers.entity_registry."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RegistryEntry:
+    entity_id: str
+    unique_id: Optional[str] = None
+
+
+class EntityRegistry:
+    """Very small registry representation."""
+
+    def __init__(self) -> None:
+        self.entities: dict[str, RegistryEntry] = {}
+
+    def async_get(self, entity_id: str) -> Optional[RegistryEntry]:
+        return self.entities.get(entity_id)
+
+
+def async_get(hass):  # pragma: no cover - compatibility
+    return EntityRegistry()
+
+
+__all__ = ["EntityRegistry", "RegistryEntry", "async_get"]

--- a/tests/stubs/homeassistant/helpers/update_coordinator.py
+++ b/tests/stubs/homeassistant/helpers/update_coordinator.py
@@ -44,4 +44,14 @@ class DataUpdateCoordinator(Generic[T]):
         self.data = data
 
 
-__all__ = ["DataUpdateCoordinator", "UpdateFailed"]
+class CoordinatorEntity(Generic[T]):
+    """Minimal CoordinatorEntity stub."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator[T]) -> None:
+        self.coordinator = coordinator
+
+    async def async_added_to_hass(self) -> None:  # pragma: no cover - compatibility
+        return None
+
+
+__all__ = ["DataUpdateCoordinator", "UpdateFailed", "CoordinatorEntity"]

--- a/tests/stubs/homeassistant/util/__init__.py
+++ b/tests/stubs/homeassistant/util/__init__.py
@@ -1,3 +1,20 @@
 """Utility package placeholder for Home Assistant stubs."""
 
-__all__: list[str] = []
+from functools import wraps
+from typing import Any, Callable
+
+
+def Throttle(min_time):  # noqa: N802 - mimic Home Assistant naming
+    """Return a decorator that ignores throttling in tests."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["Throttle"]

--- a/tests/test_sensor_vpn_clients.py
+++ b/tests/test_sensor_vpn_clients.py
@@ -1,0 +1,51 @@
+from custom_components.unifi_gateway_refactored.sensor import (
+    _format_vpn_connected_clients,
+)
+
+
+def test_format_vpn_connected_clients_extracts_values():
+    raw = {
+        "connected_clients": [
+            {
+                "name": "Client A",
+                "remote_ip": "1.2.3.4",
+                "assigned_ip": "10.0.0.5",
+                "geoip": {
+                    "country": "Poland",
+                    "city": "Warsaw",
+                    "isp": "ISP1",
+                },
+            },
+            {
+                "user": "Client B",
+                "public_ip": "5.6.7.8",
+                "client": {"ip": "10.0.0.6"},
+                "ip_geo": {
+                    "country_name": "Germany",
+                    "region": "Berlin",
+                },
+                "isp_info": {"organization": "ISP2"},
+            },
+        ]
+    }
+
+    assert _format_vpn_connected_clients(raw) == [
+        "Client A ~ 1.2.3.4 | 10.0.0.5 | Poland | Warsaw | ISP1",
+        "Client B ~ 5.6.7.8 | 10.0.0.6 | Germany | Berlin | ISP2",
+    ]
+
+
+def test_format_vpn_connected_clients_handles_missing_fields():
+    raw = {
+        "clients": {
+            "items": [
+                {
+                    "name": "Client C",
+                }
+            ]
+        }
+    }
+
+    assert _format_vpn_connected_clients(raw) == [
+        "Client C ~ Unknown | Unknown | Unknown | Unknown | Unknown"
+    ]


### PR DESCRIPTION
## Summary
- add helper utilities that collect connected VPN client metadata and format the Connected Clients attribute
- expose the Connected Clients attribute for VPN server sensors while updating it with live controller data
- extend Home Assistant stubs and add unit tests covering connected client formatting
- update the README with English and Polish end-user guidance describing setup, daily use, and VPN client visibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8ff3db09c8327aab3b61e087402a5