### PR TITLE
Add gateway reset control button

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -1454,6 +1454,20 @@ class UniFiOSClient:
                 pass
             return result
 
+    def restart_gateway(self, mac: Optional[str] = None):
+        """Trigger a soft restart of the UniFi gateway device."""
+
+        if mac is None:
+            mac = self.get_gateway_mac()
+        payload: Dict[str, Any] = {"cmd": "restart"}
+        if mac:
+            payload["mac"] = mac
+
+        result, _ = self._call_speedtest_endpoint(
+            "POST", "cmd/devmgr", payload=payload
+        )
+        return result
+
     def get_speedtest_status(self, mac: Optional[str] = None):
         if mac is None:
             mac = self.get_gateway_mac()

--- a/custom_components/unifi_gateway_refactored/utils.py
+++ b/custom_components/unifi_gateway_refactored/utils.py
@@ -9,4 +9,13 @@ def build_speedtest_button_unique_id(entry_id: str) -> str:
     return f"{entry_id}_run_speedtest"
 
 
-__all__ = ["build_speedtest_button_unique_id"]
+def build_reset_button_unique_id(entry_id: str) -> str:
+    """Return a stable unique ID for the Reset Gateway button entity."""
+
+    return f"{entry_id}_reset_gateway"
+
+
+__all__ = [
+    "build_speedtest_button_unique_id",
+    "build_reset_button_unique_id",
+]


### PR DESCRIPTION
## Summary
- add a dedicated button entity that resets the UniFi gateway and appears under device controls
- expose a client helper and unique ID builder to support the new reset button

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d927e32e148327ad92212f3187993b