### PR TITLE
Add WHOIS enrichment for VPN clients

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -8,7 +8,8 @@
   "iot_class": "local_polling",
   "requirements": [
     "requests>=2.31.0",
-    "async-timeout>=4.0.0"
+    "async-timeout>=4.0.0",
+    "ipwhois>=1.2.0"
   ],
   "codeowners": [
     "@robert-machejek"


### PR DESCRIPTION
## Summary
- rename the VPN sensor attribute for HTML client details to `connected_clients_html`
- enrich VPN client metadata by performing WHOIS lookups for remote IP addresses
- cache WHOIS responses and expose the new dependency required for lookups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d94c7f8070832788e0066f22e79f10