### PR TITLE
Refine WHOIS enrichment for connected VPN clients

### DIFF
--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -887,18 +887,23 @@ def _enrich_remote_ip_details(
     if not details:
         return city, country, isp
 
-    if not city or city == "Unknown":
-        candidate = details.get("city") or details.get("state")
-        if candidate:
-            city = _normalize_client_field(candidate)
+    candidate_city = details.get("city") or details.get("state")
+    if candidate_city:
+        city = _normalize_client_field(candidate_city)
 
-    if not country or country == "Unknown":
-        candidate = details.get("country")
-        if candidate:
-            country = _normalize_client_field(candidate)
+    candidate_country = details.get("country")
+    if candidate_country:
+        country = _normalize_client_field(candidate_country)
+    elif not country or country == "Unknown":
+        candidate_country = details.get("state")
+        if candidate_country:
+            country = _normalize_client_field(candidate_country)
 
-    if not isp or isp == "Unknown":
-        for key in ("isp", "asn_description", "asn"):
+    candidate_isp = details.get("isp")
+    if candidate_isp:
+        isp = _normalize_client_field(candidate_isp)
+    elif not isp or isp == "Unknown":
+        for key in ("asn_description", "asn"):
             candidate = details.get(key)
             if candidate:
                 isp = _normalize_client_field(candidate)

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -1577,10 +1577,17 @@ class UniFiGatewayVpnUsageSensor(SensorEntity):
         subnet_value = self._resolve_network_subnet()
         if subnet_value:
             attrs["subnet"] = subnet_value
-        attrs["Connected Clients"] = list(self._connected_clients)
+        attrs["connected_clients"] = list(self._connected_clients)
         if self._connected_clients_html is not None:
             attrs["connected_clients_html"] = self._connected_clients_html
         return attrs
+
+    @property
+    def extra_state_attribute_names(self) -> Dict[str, str]:
+        names: Dict[str, str] = {"connected_clients": "Connected Clients"}
+        if self._connected_clients_html is not None:
+            names["connected_clients_html"] = "Connected Clients HTML"
+        return names
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -1584,10 +1584,10 @@ class UniFiGatewayVpnUsageSensor(SensorEntity):
 
     @property
     def extra_state_attribute_names(self) -> Dict[str, str]:
-        names: Dict[str, str] = {"connected_clients": "Connected Clients"}
-        if self._connected_clients_html is not None:
-            names["connected_clients_html"] = "Connected Clients HTML"
-        return names
+        return {
+            "connected_clients": "Connected Clients",
+            "connected_clients_html": "Connected Clients HTML",
+        }
 
     @property
     def device_info(self) -> Dict[str, Any]:

--- a/tests/test_sensor_vpn_clients.py
+++ b/tests/test_sensor_vpn_clients.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from custom_components.unifi_gateway_refactored.sensor import (
     _format_vpn_connected_clients,
 )
@@ -29,10 +31,17 @@ def test_format_vpn_connected_clients_extracts_values():
         ]
     }
 
-    assert _format_vpn_connected_clients(raw) == [
-        "Client A ~ 1.2.3.4 | 10.0.0.5 | Poland | Warsaw | ISP1",
-        "Client B ~ 5.6.7.8 | 10.0.0.6 | Germany | Berlin | ISP2",
-    ]
+    with patch(
+        "custom_components.unifi_gateway_refactored.sensor._lookup_remote_ip_whois",
+        side_effect=[
+            {"city": "Poznań", "country": "Poland", "isp": "ISP Name A"},
+            {"city": "Munich", "country": "Germany", "isp": "ISP Name B"},
+        ],
+    ):
+        assert _format_vpn_connected_clients(raw) == [
+            "Client A ~ 1.2.3.4 | 10.0.0.5 | Poland | Poznań | ISP Name A",
+            "Client B ~ 5.6.7.8 | 10.0.0.6 | Germany | Munich | ISP Name B",
+        ]
 
 
 def test_format_vpn_connected_clients_handles_missing_fields():

--- a/tests/test_sensor_vpn_clients.py
+++ b/tests/test_sensor_vpn_clients.py
@@ -1,7 +1,9 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from custom_components.unifi_gateway_refactored.sensor import (
     _format_vpn_connected_clients,
+    UniFiGatewayVpnUsageSensor,
 )
 
 
@@ -58,3 +60,32 @@ def test_format_vpn_connected_clients_handles_missing_fields():
     assert _format_vpn_connected_clients(raw) == [
         "Client C ~ Unknown | Unknown | Unknown | Unknown | Unknown"
     ]
+
+
+class _DummyClient:
+    def instance_key(self) -> str:
+        return "dummy"
+
+
+def test_vpn_sensor_attribute_display_names():
+    sensor = UniFiGatewayVpnUsageSensor(
+        coordinator=SimpleNamespace(data=None),
+        client=_DummyClient(),
+        entry_id="entry-id",
+        base_name="Gateway",
+        server={},
+        linked_network={},
+        unique_id="unique",
+    )
+
+    assert sensor.extra_state_attribute_names == {
+        "connected_clients": "Connected Clients",
+        "connected_clients_html": "Connected Clients HTML",
+    }
+
+    sensor._connected_clients_html = "<p>content</p>"
+
+    assert sensor.extra_state_attribute_names == {
+        "connected_clients": "Connected Clients",
+        "connected_clients_html": "Connected Clients HTML",
+    }


### PR DESCRIPTION
## Summary
- prefer WHOIS city information for connected client details and use ISP name when available
- update VPN connected client formatting test to stub WHOIS responses that drive the new output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d9517bc6f8832785205c0d316f8167