### PR TITLE
Fix config flow validation without ConfigEntry

### DIFF
--- a/custom_components/unifi_gateway_refactory/config_flow.py
+++ b/custom_components/unifi_gateway_refactory/config_flow.py
@@ -27,13 +27,7 @@ from .coordinator import AuthFailedError, GatewayApiError, UniFiGatewayApiClient
 async def _async_validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the provided configuration data."""
 
-    dummy_entry = config_entries.ConfigEntry(
-        entry_id="validation",
-        data=data,
-        title=data.get(CONF_HOST, "UniFi Gateway"),
-        options={},
-    )
-    client = UniFiGatewayApiClient(hass, dummy_entry)
+    client = UniFiGatewayApiClient(hass, data)
     await client.fetch_metrics()
     return {"title": data[CONF_HOST]}
 


### PR DESCRIPTION
## Summary
- build the API client during config flow validation without constructing a temporary ConfigEntry
- teach the UniFi Gateway API client to accept raw mapping data or a ConfigEntry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db731200248327b7488c352b633049