### PR TITLE
Handle unexpected errors during config validation

### DIFF
--- a/custom_components/unifi_gateway_refactory/config_flow.py
+++ b/custom_components/unifi_gateway_refactory/config_flow.py
@@ -28,7 +28,12 @@ async def _async_validate_input(hass: HomeAssistant, data: dict[str, Any]) -> di
     """Validate the provided configuration data."""
 
     client = UniFiGatewayApiClient(hass, data)
-    await client.fetch_metrics()
+    try:
+        await client.fetch_metrics()
+    except GatewayApiError:
+        raise
+    except Exception as err:  # pragma: no cover - defensive
+        raise GatewayApiError("Unexpected error during validation") from err
     return {"title": data[CONF_HOST]}
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -77,6 +77,37 @@ def test_invalid_auth(
     assert result["errors"]["base"] == "invalid_auth"
 
 
+def test_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+    flow: config_flow.UniFiGatewayConfigFlow,
+    event_loop,
+) -> None:
+    class _Client:
+        def __init__(self, hass, data):
+            self.hass = hass
+            self.data = data
+
+        async def fetch_metrics(self):
+            raise ValueError("boom")
+
+    monkeypatch.setattr(config_flow, "UniFiGatewayApiClient", _Client)
+
+    result = event_loop.run_until_complete(
+        flow.async_step_user(
+            {
+                CONF_HOST: "gateway.local",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_SITE: DEFAULT_SITE,
+                CONF_VERIFY_SSL: True,
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
 def test_options_flow(monkeypatch: pytest.MonkeyPatch, event_loop) -> None:
     entry = config_entries.ConfigEntry(
         entry_id="entry",


### PR DESCRIPTION
## Summary
- guard the UniFi Gateway config validation against unexpected exceptions
- surface unexpected validation failures to the UI as connection errors instead of a server 500
- add regression test covering the new defensive error handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db766523788327a483df0cc71a7562