### PR TITLE
Implement session-based login for UniFi Gateway integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ fully UI-driven configuration flow.
 
 ### What this integration does for you
 
+- Uses session-based authentication with UniFi OS so controllers requiring
+  `api/login` cookies continue to work without 401/403 errors.
 - Uses a fully asynchronous data coordinator to poll UniFi OS health and WLAN
   endpoints without blocking Home Assistant.
 - Provides a complete Config Flow and Options Flow that let you adjust
@@ -37,8 +39,9 @@ fully UI-driven configuration flow.
 
 1. In Home Assistant navigate to **Settings → Devices & Services → Add
    Integration** and search for **UniFi Gateway Dashboard Analyzer**.
-2. Enter the controller address, site and credentials (local UniFi OS username
-   and password). The form validates everything before saving.
+2. Enter the controller address (make sure to include the correct port, usually
+   `443` or `8443`), site and credentials (local UniFi OS username and password).
+   The form validates everything before saving.
 3. After the initial setup you can revisit the entry and use **Configure** to
    adjust connection details without deleting the integration.
 
@@ -64,6 +67,8 @@ fully UI-driven configuration flow.
 
 ### Co daje ta integracja
 
+- Korzysta z logowania sesyjnego UniFi OS, więc kontrolery wymagające
+  endpointu `api/login` działają poprawnie bez błędów 401/403.
 - Udostępnia w Home Assistant wskaźniki WAN, LAN, WLAN i stanu internetu z
   bramy UniFi, aby łatwo kontrolować dostępność łącza, przepustowość i alarmy.
 - Śledzi wersje oprogramowania urządzeń UniFi i wskazuje dostępne aktualizacje
@@ -80,8 +85,9 @@ fully UI-driven configuration flow.
 
 1. W Home Assistant przejdź do **Ustawienia → Urządzenia i usługi → Dodaj
    integrację** i wyszukaj **UniFi Gateway Dashboard Analyzer**.
-2. Podaj adres kontrolera, witrynę oraz dane logowania (lokalny użytkownik i
-   hasło UniFi OS). Formularz sprawdza poprawność przed zapisaniem.
+2. Podaj adres kontrolera (pamiętaj o właściwym porcie – zazwyczaj `443` lub
+   `8443`), witrynę oraz dane logowania (lokalny użytkownik i hasło UniFi OS).
+   Formularz sprawdza poprawność przed zapisaniem.
 3. Po instalacji możesz wybrać **Konfiguruj** przy wpisie integracji, aby w
    każdej chwili zmienić parametry połączenia.
 

--- a/custom_components/unifi_gateway_refactory/config_flow.py
+++ b/custom_components/unifi_gateway_refactory/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import Awaitable
 from typing import Any, cast
 
@@ -29,6 +30,9 @@ from .const import (
     MIN_SCAN_INTERVAL,
 )
 from .coordinator import AuthFailedError, GatewayApiError, UniFiGatewayApiClient
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def _resolve_flow_result(
@@ -69,6 +73,9 @@ class UniFiGatewayConfigFlow(  # type: ignore[misc, call-arg]
             except AuthFailedError:
                 errors["base"] = "invalid_auth"
             except GatewayApiError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pragma: no cover - defensive logging
+                _LOGGER.exception("Unexpected error during UniFi Gateway config flow")
                 errors["base"] = "cannot_connect"
             else:
                 await self.async_set_unique_id(user_input[CONF_HOST])

--- a/custom_components/unifi_gateway_refactory/coordinator.py
+++ b/custom_components/unifi_gateway_refactory/coordinator.py
@@ -99,6 +99,7 @@ class UniFiGatewayApiClient:
         self._site = data.get(CONF_SITE, DEFAULT_SITE)
         self._username = data.get(CONF_USERNAME, "")
         self._password = data.get(CONF_PASSWORD, "")
+        self._auth = aiohttp.BasicAuth(self._username, self._password)
         limit = int(
             opts.get(
                 CONF_RATE_LIMIT,
@@ -139,14 +140,17 @@ class UniFiGatewayApiClient:
             if self._logged_in:
                 return
             await self._login()
-            self._logged_in = True
 
     async def _login(self) -> None:
         """Perform UniFi OS login exchanging credentials for a session."""
 
-        payload = {"username": self._username, "password": self._password}
+        payload = {"username": self._auth.login, "password": self._auth.password}
+        self._csrf_token = None
+        self._logged_in = False
         last_error: Exception | None = None
-        for path in ("/api/auth/login", "/api/login"):
+        last_status: int | None = None
+        last_text: str | None = None
+        for path in ("/api/login", "/api/auth/login"):
             url = urljoin(self.base_url + "/", path.lstrip("/"))
             try:
                 response = await self._session.post(
@@ -160,16 +164,14 @@ class UniFiGatewayApiClient:
                 continue
 
             async with response:
-                if response.status in (400, 401, 403):
-                    raise AuthFailedError("Invalid credentials provided")
-                if response.status >= 500:
-                    last_error = GatewayApiError(
-                        f"Login failed with status {response.status}"
-                    )
-                    continue
-                if response.status >= 400:
-                    last_error = GatewayApiError(
-                        f"Unexpected response {response.status} during login"
+                last_status = response.status
+                last_text = await response.text()
+                if response.status != 200:
+                    _LOGGER.debug(
+                        "Login to %s failed with status %s: %s",
+                        path,
+                        response.status,
+                        last_text,
                     )
                     continue
 
@@ -180,13 +182,11 @@ class UniFiGatewayApiClient:
                     if csrf_cookie is not None:
                         token = csrf_cookie.value
                 self._csrf_token = token
+                self._logged_in = True
                 return
 
-        self._logged_in = False
-        if isinstance(last_error, AuthFailedError):
-            raise last_error
-        if isinstance(last_error, GatewayApiError):
-            raise last_error
+        if last_status is not None:
+            raise AuthFailedError(last_text or f"Login failed with status {last_status}")
         if last_error is not None:
             raise GatewayApiError(str(last_error)) from last_error
         raise GatewayApiError("Unable to authenticate with UniFi Gateway")
@@ -224,20 +224,23 @@ class UniFiGatewayApiClient:
 
         url = urljoin(self.base_url + "/", path.lstrip("/"))
         last_error: Exception | None = None
+        attempted_login = False
         for attempt in range(1, API_MAX_ATTEMPTS + 1):
-            if not self._logged_in:
-                await self._ensure_authenticated()
+            use_basic_auth = not self._logged_in and not attempted_login
             async with self._semaphore:
                 try:
                     headers = {}
-                    if self._csrf_token:
+                    if self._csrf_token and not use_basic_auth:
                         headers["x-csrf-token"] = self._csrf_token
-                    response = await self._session.request(
-                        method,
-                        url,
-                        headers=headers,
-                        timeout=aiohttp.ClientTimeout(total=API_REQUEST_TIMEOUT),
-                    )
+                    request_kwargs = {
+                        "method": method,
+                        "url": url,
+                        "headers": headers,
+                        "timeout": aiohttp.ClientTimeout(total=API_REQUEST_TIMEOUT),
+                    }
+                    if use_basic_auth:
+                        request_kwargs["auth"] = self._auth
+                    response = await self._session.request(**request_kwargs)
                 except (aiohttp.ClientError, asyncio.TimeoutError) as err:
                     last_error = err
                     _LOGGER.debug("HTTP request error on attempt %s: %s", attempt, err)
@@ -245,9 +248,14 @@ class UniFiGatewayApiClient:
                     async with response:
                         status = response.status
                         if status in (401, 403):
+                            body = await response.text()
                             self._logged_in = False
-                            if attempt == API_MAX_ATTEMPTS:
-                                raise AuthFailedError("Invalid credentials provided")
+                            self._csrf_token = None
+                            if attempted_login:
+                                raise AuthFailedError(body or "Invalid credentials provided")
+                            attempted_login = True
+                            async with self._login_lock:
+                                await self._login()
                             continue
                         if status == 204:
                             return {}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -176,9 +176,10 @@ def test_coordinator_invalid_response(
 class DummyResponse:
     """Minimal aiohttp-like response for testing retries."""
 
-    def __init__(self, status: int, payload: Any) -> None:
+    def __init__(self, status: int, payload: Any, text: str = "temporary error") -> None:
         self._status = status
         self._payload = payload
+        self._text = text
 
     async def __aenter__(self) -> "DummyResponse":
         return self
@@ -194,7 +195,7 @@ class DummyResponse:
         return self._payload
 
     async def text(self) -> str:
-        return "temporary error"
+        return self._text
 
 
 class DummySession:
@@ -236,6 +237,31 @@ class DummyLoginResponse:
 
     async def __aexit__(self, *exc: Any) -> None:
         return None
+
+    async def text(self) -> str:
+        return ""
+
+
+class AuthRetrySession:
+    """Session that first uses basic auth then retries with session cookies."""
+
+    def __init__(self, responses: list[DummyResponse], login_response: DummyLoginResponse) -> None:
+        self._responses = responses
+        self._login_response = login_response
+        self.request_calls: list[dict[str, Any]] = []
+        self.cookie_jar = DummyCookieJar({})
+        self._request_index = 0
+        self.login_calls = 0
+
+    async def request(self, *args: Any, **kwargs: Any) -> DummyResponse:
+        self.request_calls.append(kwargs)
+        index = min(self._request_index, len(self._responses) - 1)
+        self._request_index += 1
+        return self._responses[index]
+
+    async def post(self, *args: Any, **kwargs: Any) -> DummyLoginResponse:
+        self.login_calls += 1
+        return self._login_response
 
 
 class DummyLoginSession:
@@ -320,6 +346,36 @@ def test_login_falls_back_to_cookie(
 
     assert client._csrf_token == "cookie-token"
     assert session.post_calls == 1
+
+
+def test_request_reauth_on_unauthorized(
+    monkeypatch: pytest.MonkeyPatch,
+    hass,
+    config_entry: ConfigEntry,
+    event_loop,
+) -> None:
+    """Client retries without basic auth after UniFi OS login."""
+
+    responses = [
+        DummyResponse(401, {}, text="unauthorized"),
+        DummyResponse(200, {"data": []}, text="ok"),
+    ]
+    login_response = DummyLoginResponse(headers={"x-csrf-token": "csrf123"})
+    session = AuthRetrySession(responses, login_response)
+
+    with patch(
+        "custom_components.unifi_gateway_refactory.coordinator.aiohttp_client.async_get_clientsession",
+        return_value=session,
+    ):
+        client = UniFiGatewayApiClient(hass, config_entry)
+        result = event_loop.run_until_complete(client._request_json("GET", "/test"))
+
+    assert session.login_calls == 1
+    assert len(session.request_calls) == 2
+    assert session.request_calls[0].get("auth") is not None
+    assert session.request_calls[1].get("auth") is None
+    assert session.request_calls[1]["headers"].get("x-csrf-token") == "csrf123"
+    assert result == {"data": []}
 
 
 def _setup_coordinator(


### PR DESCRIPTION
## Summary
- add session-cookie login support and retry logic to the UniFi Gateway API client
- capture unexpected config flow errors and expand coordinator tests for the new auth flow
- document the session login behavior and required host port configuration in the README

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_b_68db9e3f9f24832787f56f0a9dac00c9