### PR TITLE
Align UniFi login flow with legacy attempt order

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -337,8 +337,8 @@ def test_login_uses_csrf_header(
 
     assert client._csrf_token == "abc123"
     assert session.post_calls == 1
-    assert session.calls[0]["payload"]["strict"] is True
-    assert "/api/login" in session.calls[0]["url"]
+    assert session.calls[0]["payload"]["rememberMe"] is True
+    assert "/api/auth/login" in session.calls[0]["url"]
 
 
 def test_login_falls_back_to_cookie(
@@ -362,8 +362,8 @@ def test_login_falls_back_to_cookie(
 
     assert client._csrf_token == "cookie-token"
     assert session.post_calls == 1
-    assert session.calls[0]["payload"]["strict"] is True
-    assert "/api/login" in session.calls[0]["url"]
+    assert session.calls[0]["payload"]["rememberMe"] is True
+    assert "/api/auth/login" in session.calls[0]["url"]
 
 
 def test_login_retries_with_unifi_os_payload(
@@ -388,10 +388,10 @@ def test_login_retries_with_unifi_os_payload(
         event_loop.run_until_complete(client._ensure_authenticated())
 
     assert session.post_calls == 2
-    assert "/api/login" in session.calls[0]["url"]
-    assert session.calls[0]["payload"]["strict"] is True
-    assert "/api/auth/login" in session.calls[1]["url"]
-    assert session.calls[1]["payload"]["rememberMe"] is False
+    assert "/api/auth/login" in session.calls[0]["url"]
+    assert session.calls[0]["payload"]["rememberMe"] is True
+    assert "/api/login" in session.calls[1]["url"]
+    assert session.calls[1]["payload"]["remember"] is True
     assert client._csrf_token == "csrf456"
 
 
@@ -417,10 +417,10 @@ def test_login_retries_when_csrf_missing(
         event_loop.run_until_complete(client._ensure_authenticated())
 
     assert session.post_calls == 2
-    assert "/api/login" in session.calls[0]["url"]
-    assert session.calls[0]["payload"]["strict"] is True
-    assert "/api/auth/login" in session.calls[1]["url"]
-    assert session.calls[1]["payload"]["rememberMe"] is False
+    assert "/api/auth/login" in session.calls[0]["url"]
+    assert session.calls[0]["payload"]["rememberMe"] is True
+    assert "/api/login" in session.calls[1]["url"]
+    assert session.calls[1]["payload"]["remember"] is True
     assert client._csrf_token == "csrf789"
 
 


### PR DESCRIPTION
## Summary
- reorder the UniFi OS login attempts to start with `/api/auth/login` using the legacy remember flags before falling back to `/api/login` and `/login`
- update the coordinator unit tests to reflect the new login sequence and payload expectations

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dbdf07e0288327a85854d4be0cfb93