### PR TITLE
Fix release workflow manifest path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - custom_components/unifi_gateway_refactored/manifest.json
+      - custom_components/unifi_gateway_refactory/manifest.json
   workflow_dispatch:
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
           import json
           from pathlib import Path
 
-          manifest = json.loads(Path("custom_components/unifi_gateway_refactored/manifest.json").read_text())
+          manifest = json.loads(Path("custom_components/unifi_gateway_refactory/manifest.json").read_text())
           print(manifest["version"])
           PY
           )


### PR DESCRIPTION
## Summary
- point the release workflow to the integration manifest in `custom_components/unifi_gateway_refactory`
- ensure the workflow reads the manifest version from the correct directory so tags use the right version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc3104bd988327bfb9a016788113c0