### PR TITLE
Handle duplicate config flow aborts and close UniFi client sessions

### DIFF
--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -137,6 +137,13 @@ class UniFiOSClient:
         self._clients_v2_cache: Optional[Tuple[float, List[Dict[str, Any]]]] = None
         self._vpn_servers_cache: Optional[Tuple[float, List[Dict[str, Any]]]] = None
         self._vpn_sessions_cache: Optional[Tuple[float, Dict[str, Dict[str, int]]]] = None
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+
+        session = getattr(self, "_session", None)
+        if session is not None:
+            session.close()
     def _net_base(self) -> str:
         """Return the normalized base URL for UniFi Network requests."""
 


### PR DESCRIPTION
## Summary
- close UniFi client sessions created during config flow validation to prevent unclosed connection warnings
- allow AbortFlow exceptions to propagate so duplicate configurations are aborted without being logged as unexpected errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd7b07d44483279b7ae7b319f30e56