### PR TITLE
Improve logging and WAN IPv6 handling

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -329,7 +329,6 @@ async def _async_migrate_speedtest_button_unique_id(
     except ImportError:  # pragma: no cover - defensive guard
         return
 
-    registry = er.async_get(hass)
     old_unique_id = "unifi_gateway_refactored_run_speedtest"
     new_unique_id = build_speedtest_button_unique_id(entry.entry_id)
 
@@ -413,8 +412,6 @@ async def _async_migrate_interface_unique_ids(
     if not mapping:
         _LOGGER.debug("No interface unique ID migrations required for entry %s", entry.entry_id)
         return
-
-    registry = er.async_get(hass)
 
     async def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
         if entity_entry.config_entry_id != entry.entry_id:

--- a/custom_components/unifi_gateway_refactored/binary_sensor.py
+++ b/custom_components/unifi_gateway_refactored/binary_sensor.py
@@ -5,8 +5,6 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -226,9 +226,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 raise
             except Exception as err:  # pragma: no cover - defensive guard
                 _LOGGER.exception(
-                    "Unexpected error while validating UniFi controller %s:%s",
+                    "Unexpected error while validating UniFi controller %s:%s: %s",
                     data.get(CONF_HOST),
                     data.get(CONF_PORT, DEFAULT_PORT),
+                    err,
                 )
                 errors["base"] = "unknown"
 
@@ -358,9 +359,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                     errors["base"] = "cannot_connect" if not err.expected else "unknown"
                 except Exception as err:  # pragma: no cover - defensive guard
                     _LOGGER.exception(
-                        "Unexpected error while validating UniFi controller %s:%s during options flow",
+                        "Unexpected error while validating UniFi controller %s:%s during options flow: %s",
                         merged.get(CONF_HOST),
                         merged.get(CONF_PORT, DEFAULT_PORT),
+                        err,
                     )
                     errors["base"] = "unknown"
 

--- a/custom_components/unifi_gateway_refactored/monitor.py
+++ b/custom_components/unifi_gateway_refactored/monitor.py
@@ -15,7 +15,6 @@ from .const import (
     ATTR_ERROR,
     ATTR_REASON,
     ATTR_TRACE_ID,
-    DOMAIN,
     EVT_RUN_END,
     EVT_RUN_ERROR,
     EVT_RUN_START,
@@ -206,7 +205,9 @@ class SpeedtestRunner:
         try:
             await self._coordinator.async_request_refresh()
         except Exception:  # pragma: no cover - defensive logging
-            _LOGGER.exception("Failed to refresh entities after speedtest")
+            _LOGGER.exception(
+                "UniFi Gateway speedtest: failed to refresh entities after run"
+            )
 
     async def _dispatch_result(
         self, *, success: bool, duration_ms: int, error: str | None, trace_id: str
@@ -219,7 +220,10 @@ class SpeedtestRunner:
                 trace_id=trace_id,
             )
         except Exception:  # pragma: no cover - defensive logging
-            _LOGGER.exception("Result callback raised for speedtest %s", trace_id)
+            _LOGGER.exception(
+                "UniFi Gateway speedtest: result callback raised for %s",
+                trace_id,
+            )
 
     async def async_trigger(self, reason: str) -> None:
         """Trigger a speedtest update."""
@@ -231,6 +235,13 @@ class SpeedtestRunner:
             trace_id = str(uuid.uuid4())
             start = monotonic()
             error: str | None = None
+
+            _LOGGER.info(
+                "[%s] Speedtest run started (reason=%s, entities=%s)",
+                trace_id,
+                reason,
+                ", ".join(self.entity_ids),
+            )
 
             self.hass.bus.async_fire(
                 EVT_RUN_START,
@@ -255,7 +266,8 @@ class SpeedtestRunner:
 
                 if result:
                     _LOGGER.info(
-                        "Speedtest completed: %s/%s Mbps, %s ms",
+                        "[%s] Speedtest completed: %s/%s Mbps, %s ms",
+                        trace_id,
                         result.get("download_mbps"),
                         result.get("upload_mbps"),
                         result.get("latency_ms"),
@@ -282,10 +294,10 @@ class SpeedtestRunner:
                 duration_ms = int((monotonic() - start) * 1000)
                 error = f"{type(err).__name__}: {err}"
                 _LOGGER.error(
-                    "Speedtest failed after %dms: %s (trace=%s)",
+                    "[%s] Speedtest failed after %dms: %s",
+                    trace_id,
                     duration_ms,
                     error,
-                    trace_id,
                 )
                 self.hass.bus.async_fire(
                     EVT_RUN_ERROR,

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -895,6 +895,9 @@ _WAN_IPV6_KEYS: tuple[str, ...] = (
     "wan_ip6",
     "wan_ipv6_address",
     "wan_ipv6_ip",
+    "ipv6_address",
+    "global_ipv6",
+    "public_ip6",
 )
 
 
@@ -2626,12 +2629,17 @@ class UniFiGatewayWanIpv6Sensor(UniFiGatewayWanSensorBase):
         health = self._wan_health_record()
         ipv6, source = _extract_wan_value_with_source(link, health, _WAN_IPV6_KEYS)
         if ipv6:
+            if source == "wan_link":
+                normalized_source = "link"
+            elif source == "wan_health":
+                normalized_source = "health"
+            else:
+                normalized_source = source or "unknown"
             self._last_ipv6 = ipv6
-            self._last_source = source or "unknown"
+            self._last_source = normalized_source
             return ipv6
         if self._last_ipv6:
-            if not self._last_source:
-                self._last_source = "cached"
+            self._last_source = "cached"
             return self._last_ipv6
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ STUBS_PATH = Path(__file__).parent / "stubs"
 if str(STUBS_PATH) not in sys.path:
     sys.path.insert(0, str(STUBS_PATH))
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -4,17 +4,13 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 import threading
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+import pytest
 
-from custom_components.unifi_gateway_refactored.monitor import (
-    SpeedtestRunner,
-    DEFAULT_MAX_WAIT_S,
-    DEFAULT_POLL_INTERVAL,
-)
+from homeassistant.core import HomeAssistant
+
+from custom_components.unifi_gateway_refactored.monitor import SpeedtestRunner
 
 @pytest.fixture
 def mock_client():

--- a/tests/test_sensor_ipv6.py
+++ b/tests/test_sensor_ipv6.py
@@ -99,7 +99,7 @@ def test_wan_ipv6_sensor_reports_details():
     assert value == "2001:db8::1"
     attrs = sensor.extra_state_attributes
     assert attrs["last_ipv6"] == "2001:db8::1"
-    assert attrs["source"] == "wan_link"
+    assert attrs["source"] == "link"
     assert attrs["gateway_ipv6"] == "fe80::1"
     assert attrs["prefix"] == "2001:db8::/64"
 
@@ -123,7 +123,7 @@ def test_wan_ipv6_sensor_ignores_placeholder_values():
     assert value == "2001:db8::2"
     attrs = sensor.extra_state_attributes
     assert attrs["last_ipv6"] == "2001:db8::2"
-    assert attrs["source"] == "wan_health"
+    assert attrs["source"] == "health"
     assert attrs["gateway_ipv6"] == "fe80::2"
     assert attrs["prefix"] == "2001:db8::/60"
 


### PR DESCRIPTION
## Summary
- harden UniFi client request logging and drop unused network/VPN helpers
- add trace-aware speedtest logging and tidy defensive handlers
- extend WAN IPv6 sensor fallbacks and normalize the reported source values
- redact login endpoint identifiers from authentication debug logs to avoid leaking sensitive configuration

## Testing
- pytest
- ruff check custom_components/unifi_gateway_refactored
- ruff check .

------
https://chatgpt.com/codex/tasks/task_b_68de17a771288327ae17910ee39ae353