### PR TITLE
Add manifest and update hacs.json for UniFi Gateway Dashboard Analyzer

### DIFF
--- a/custom_components/manifest.json
+++ b/custom_components/manifest.json
@@ -1,0 +1,26 @@
+{
+  "domain": "unifi_gateway_refactored",
+  "name": "UniFi Gateway Dashboard Analyzer",
+  "version": "0.6.1",
+  "config_flow": true,
+  "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
+  "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",
+  "iot_class": "local_polling",
+  "requirements": [
+    "requests>=2.31.0",
+    "async-timeout>=4.0.0",
+    "ipwhois>=1.2.0"
+  ],
+  "codeowners": [
+    "@rupert12"
+  ],
+  "integration_type": "hub",
+  "loggers": [
+    "custom_components.unifi_gateway_refactored",
+    "custom_components.unifi_gateway_refactored.coordinator",
+    "custom_components.unifi_gateway_refactored.monitor",
+    "custom_components.unifi_gateway_refactored.unifi_client"
+  ],
+  "logo": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/logo.svg",
+  "icon": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/icon.svg"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,9 @@
 {
   "name": "UniFi Gateway Dashboard Analyzer",
+  "domains": ["unifi_gateway_refactored"],
+  "homeassistant": "2024.2.0",
   "render_readme": true,
-  "logo": "images/logo.svg",
-  "icon": "images/icon.svg"
+  "zip_release": true,
+  "logo": "https://raw.githubusercontent.com/rupert12pl/unifi_gatway_refacoty/3a35a31dc20172703a6b467a1eea146053d0bd51/images/logo.svg",
+  "icon": "https://raw.githubusercontent.com/rupert12pl/unifi_gatway_refacoty/3a35a31dc20172703a6b467a1eea146053d0bd51/images/icon.svg"
 }


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
