### PR TITLE
fix: update HACS configuration and manifest paths

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -21,6 +21,6 @@
     "custom_components.unifi_gateway_refactored.monitor",
     "custom_components.unifi_gateway_refactored.unifi_client"
   ],
-  "logo": "https://raw.githubusercontent.com/rupert12pl/unifi_gatway_refacoty/main/custom_components/logo.svg",
-  "icon": "https://raw.githubusercontent.com/rupert12pl/unifi_gatway_refacoty/main/custom_components/icon.svg"
+  "logo": "logo.svg",
+  "icon": "icon.svg"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,9 +1,9 @@
 {
   "name": "UniFi Gateway Dashboard Analyzer",
+  "content_in_root": false,
   "country": ["PL", "US", "GB"],
-  "domains": ["unifi_gateway_refactored"],
+  "domain": ["unifi_gateway_refactored"],
   "homeassistant": "2024.2.0",
   "render_readme": true,
-  "zip_release": true,
-  "filename": "unifi_gateway_refactored.zip"
+  "zip_release": true
 }


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
