### PR TITLE
V.0.6.5

### DIFF
--- a/custom_components/unifi_gateway_refactored/__init__.py
+++ b/custom_components/unifi_gateway_refactored/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Optional, TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers import entity_registry as er
+    from homeassistant.helpers.entity_registry import RegistryEntry
     from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -337,7 +337,7 @@ async def _async_migrate_speedtest_button_unique_id(
 
     migrated = False
 
-    async def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+    async def _migrate(entity_entry: "RegistryEntry") -> dict[str, str] | None:
         nonlocal migrated
         if entity_entry.config_entry_id != entry.entry_id:
             return None
@@ -413,7 +413,7 @@ async def _async_migrate_interface_unique_ids(
         _LOGGER.debug("No interface unique ID migrations required for entry %s", entry.entry_id)
         return
 
-    async def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+    async def _migrate(entity_entry: "RegistryEntry") -> dict[str, str] | None:
         if entity_entry.config_entry_id != entry.entry_id:
             return None
         unique_id = entity_entry.unique_id
@@ -430,5 +430,3 @@ async def _async_migrate_interface_unique_ids(
         len(mapping),
         entry.entry_id,
     )
-
-

--- a/custom_components/unifi_gateway_refactored/button.py
+++ b/custom_components/unifi_gateway_refactored/button.py
@@ -36,6 +36,7 @@ async def async_setup_entry(
         True,
     )
 
+
 class SpeedtestRunButton(ButtonEntity):
     _attr_name = "Run Speedtest"
     _attr_icon = "mdi:speedometer"

--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -41,6 +41,7 @@ from .unifi_client import UniFiOSClient, APIError, AuthError, ConnectivityError
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def _validate(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]:
     def _sync():
         client = UniFiOSClient(
@@ -60,6 +61,7 @@ async def _validate(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]
             client.close()
         return {"ping": ping, "sites": sites}
     return await hass.async_add_executor_job(_sync)
+
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
@@ -204,7 +206,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         data[key] = normalized
                         self._cached[key] = normalized
             try:
-                assert self.hass is not None
+                # Ensure Home Assistant context is available before validation.
+                assert self.hass is not None  # nosec B101
                 await _validate(self.hass, data)
                 await self.async_set_unique_id(
                     f"{data[CONF_HOST]}:{data.get(CONF_PORT, DEFAULT_PORT)}"
@@ -308,6 +311,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
         return OptionsFlow(config_entry)
 
+
 class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, entry: config_entries.ConfigEntry) -> None:
         self._entry = entry
@@ -344,7 +348,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "missing_auth"
             else:
                 try:
-                    assert self.hass is not None
+                    # Ensure Home Assistant context is available before validation.
+                    assert self.hass is not None  # nosec B101
                     await _validate(self.hass, merged)
                     return self.async_create_entry(title="", data=cleaned)
                 except AuthError:

--- a/custom_components/unifi_gateway_refactored/const.py
+++ b/custom_components/unifi_gateway_refactored/const.py
@@ -4,7 +4,8 @@ DOMAIN = "unifi_gateway_refactored"
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
 
 CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
+# Placeholder configuration keys for UI forms.
+CONF_PASSWORD = "password"  # nosec B105
 CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_SITE_ID = "site_id"
@@ -42,4 +43,3 @@ ATTR_REASON = "reason"
 ATTR_ENTITY_IDS = "entity_ids"
 ATTR_DURATION_MS = "duration_ms"
 ATTR_ERROR = "error"
-

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -236,7 +236,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
         if interval > 0:
             last_ts = self._speedtest_last_timestamp(speedtest)
             now_ts = time.time()
-            
+
             should_trigger = False
             if not speedtest:
                 should_trigger = True
@@ -244,19 +244,19 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             elif last_ts and (now_ts - last_ts) >= interval:
                 should_trigger = True
                 reason = f"stale ({int(now_ts - last_ts)}s old)"
-                
-            if should_trigger:
-                cooldown = max(interval, 60)
-                try:
-                    self._client.maybe_start_speedtest(cooldown_sec=cooldown)
-                    _LOGGER.info(
-                        "Triggered speedtest (reason=%s, interval=%ss, cooldown=%ss)",
-                        reason,
-                        interval,
-                        cooldown
-                    )
-                except APIError as err:
-                    _LOGGER.warning("Failed to trigger speedtest: %s", err)
+
+        if should_trigger:
+            cooldown = max(interval, 60)
+            try:
+                self._client.maybe_start_speedtest(cooldown_sec=cooldown)
+                _LOGGER.info(
+                    "Triggered speedtest (reason=%s, interval=%ss, cooldown=%ss)",
+                    reason,
+                    interval,
+                    cooldown
+                )
+            except APIError as err:
+                _LOGGER.warning("Failed to trigger speedtest: %s", err)
 
         data = UniFiGatewayData(
             controller=controller_info,

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/custom_components/unifi_gateway_refactored/monitor.py
+++ b/custom_components/unifi_gateway_refactored/monitor.py
@@ -25,12 +25,12 @@ from .unifi_client import APIError, UniFiOSClient
 _LOGGER = logging.getLogger(__name__)
 
 
-
 class ResultCallback(Protocol):
     async def __call__(
         self, *, success: bool, duration_ms: int, error: str | None, trace_id: str
     ) -> None:
         ...
+
 
 DEFAULT_MAX_WAIT_S = 600
 DEFAULT_POLL_INTERVAL = 5.0

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -20,6 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Type,
     Protocol,
+    Union,
     cast,
 )
 
@@ -962,15 +963,42 @@ def _extract_wan_value_with_source(
     link: Optional[Dict[str, Any]],
     health: Optional[Dict[str, Any]],
     keys: Iterable[str],
+    *,
+    version: Optional[int] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
+    link_local_candidate: Optional[Tuple[str, str]] = None
+
+    def _normalize(value: Any, source: str) -> Optional[Tuple[str, str]]:
+        nonlocal link_local_candidate
+        if version in (4, 6):
+            parsed = _extract_ip_from_value(value, version=version)
+        else:
+            parsed = value
+        if not parsed:
+            return None
+        if version == 6:
+            try:
+                address = ipaddress.ip_address(parsed)
+            except ValueError:
+                return parsed, source
+            if isinstance(address, ipaddress.IPv6Address) and address.is_link_local:
+                if link_local_candidate is None:
+                    link_local_candidate = (parsed, source)
+                return None
+        return parsed, source
+
     if link:
         value = _value_from_record(link, keys)
-        if value:
-            return value, "wan_link"
+        normalized = _normalize(value, "wan_link")
+        if normalized:
+            return normalized
     if health:
         value = _value_from_record(health, keys)
-        if value:
-            return value, "wan_health"
+        normalized = _normalize(value, "wan_health")
+        if normalized:
+            return normalized
+    if link_local_candidate:
+        return link_local_candidate
     return None, None
 
 
@@ -978,8 +1006,12 @@ def _extract_wan_value(
     link: Optional[Dict[str, Any]],
     health: Optional[Dict[str, Any]],
     keys: Iterable[str],
+    *,
+    version: Optional[int] = None,
 ) -> Optional[str]:
-    value, _ = _extract_wan_value_with_source(link, health, keys)
+    value, _ = _extract_wan_value_with_source(
+        link, health, keys, version=version
+    )
     return value
 
 
@@ -2511,9 +2543,11 @@ class UniFiGatewayWanStatusSensor(UniFiGatewayWanSensorBase):
         health = self._wan_health_record()
         link_dict = link or {}
         health_dict = health or {}
-        ip, ip_source = _extract_wan_value_with_source(link, health, _WAN_IPV4_KEYS)
+        ip, ip_source = _extract_wan_value_with_source(
+            link, health, _WAN_IPV4_KEYS, version=4
+        )
         ipv6, ipv6_source = _extract_wan_value_with_source(
-            link, health, _WAN_IPV6_KEYS
+            link, health, _WAN_IPV6_KEYS, version=6
         )
         attrs = {
             "name": self._link_name,
@@ -2594,7 +2628,9 @@ class UniFiGatewayWanIpSensor(UniFiGatewayWanSensorBase):
     def native_value(self) -> Optional[str]:
         link = self._link()
         health = self._wan_health_record()
-        ip, source = _extract_wan_value_with_source(link, health, _WAN_IPV4_KEYS)
+        ip, source = _extract_wan_value_with_source(
+            link, health, _WAN_IPV4_KEYS, version=4
+        )
         if ip:
             self._last_ip = ip
             self._last_source = source or "unknown"
@@ -2625,7 +2661,9 @@ class UniFiGatewayWanIpSensor(UniFiGatewayWanSensorBase):
                     "tunnel_network",
                 ),
             ),
-            "ipv6": _extract_wan_value(link, health, _WAN_IPV6_KEYS),
+            "ipv6": _extract_wan_value(
+                link, health, _WAN_IPV6_KEYS, version=6
+            ),
         }
         attrs.update(self._controller_attrs())
         return attrs
@@ -2662,7 +2700,9 @@ class UniFiGatewayWanIpv6Sensor(UniFiGatewayWanSensorBase):
     def native_value(self) -> Optional[str]:
         link = self._link()
         health = self._wan_health_record()
-        ipv6, source = _extract_wan_value_with_source(link, health, _WAN_IPV6_KEYS)
+        ipv6, source = _extract_wan_value_with_source(
+            link, health, _WAN_IPV6_KEYS, version=6
+        )
         if ipv6:
             if source == "wan_link":
                 normalized_source = "link"
@@ -2685,7 +2725,9 @@ class UniFiGatewayWanIpv6Sensor(UniFiGatewayWanSensorBase):
         attrs = {
             "last_ipv6": self._last_ipv6,
             "source": self._last_source or ("cached" if self._last_ipv6 else None),
-            "gateway_ipv6": _extract_wan_value(link, health, _WAN_GATEWAY_IPV6_KEYS),
+            "gateway_ipv6": _extract_wan_value(
+                link, health, _WAN_GATEWAY_IPV6_KEYS, version=6
+            ),
             "prefix": _extract_wan_value(link, health, _WAN_IPV6_PREFIX_KEYS),
         }
         attrs.update(self._controller_attrs())
@@ -3165,48 +3207,94 @@ def _to_ip_network(value: Optional[str]):
         return None
 
 
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
 def _extract_ip_from_value(value: Any, *, version: Optional[int] = None) -> Optional[str]:
-    if value in (None, ""):
-        return None
-    if isinstance(value, str):
-        candidate = value.strip()
-        if not candidate:
-            return None
-        if "/" in candidate:
-            try:
-                interface = ipaddress.ip_interface(candidate)
-                if version and interface.ip.version != version:
-                    return None
-                return str(interface.ip)
-            except ValueError:
-                pass
-            prefix, _, _ = candidate.partition("/")
-            try:
-                parsed = ipaddress.ip_address(prefix.strip())
-                if version and parsed.version != version:
-                    return None
-                return str(parsed)
-            except ValueError:
-                return None
+    fallback_link_local: Optional[str] = None
+
+    def _strip_ipv6_brackets(text: str) -> str:
+        if text.startswith("["):
+            closing = text.find("]")
+            if closing != -1:
+                inside = text[1:closing]
+                remainder = text[closing + 1 :]
+                if remainder.startswith(":") and remainder[1:].isdigit():
+                    remainder = ""
+                return inside + remainder
+        return text
+
+    def _strip_ipv6_scope_id(text: str) -> str:
+        if "%" not in text:
+            return text
+        head, _, tail = text.partition("%")
+        if not tail:
+            return head
+        for delimiter in ("/", "]", " "):
+            if delimiter in tail:
+                _, sep, remainder = tail.partition(delimiter)
+                return head + sep + remainder
+        if tail.startswith(":") and tail[1:].isdigit():
+            return head
+        return head
+
+    def _parse_ip(text: str) -> Optional[IPAddress]:
+        normalized = _strip_ipv6_scope_id(text)
         try:
-            parsed = ipaddress.ip_address(candidate)
-            if version and parsed.version != version:
-                return None
-            return str(parsed)
+            return ipaddress.ip_address(normalized)
         except ValueError:
             return None
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            result = _extract_ip_from_value(item, version=version)
-            if result:
-                return result
+
+    def _handle(parsed: IPAddress) -> Optional[str]:
+        nonlocal fallback_link_local
+        if version and parsed.version != version:
+            return None
+        if isinstance(parsed, ipaddress.IPv6Address) and parsed.is_link_local:
+            if fallback_link_local is None:
+                fallback_link_local = str(parsed)
+            return None
+        return str(parsed)
+
+    def _extract(candidate: Any) -> Optional[str]:
+        if candidate in (None, ""):
+            return None
+        if isinstance(candidate, str):
+            cleaned = candidate.strip()
+            if not cleaned:
+                return None
+            cleaned = _strip_ipv6_brackets(cleaned)
+            if "/" in cleaned:
+                prefix, _, _ = cleaned.partition("/")
+                parsed = _parse_ip(prefix.strip())
+                if parsed:
+                    handled = _handle(parsed)
+                    if handled:
+                        return handled
+            parsed = _parse_ip(cleaned)
+            if parsed:
+                return _handle(parsed)
+            return None
+        if isinstance(candidate, (list, tuple)):
+            for item in candidate:
+                result = _extract(item)
+                if result:
+                    return result
+            return None
+        if isinstance(candidate, dict):
+            for key in ("ip", "address", "gateway", "value"):
+                if key not in candidate:
+                    continue
+                result = _extract(candidate.get(key))
+                if result:
+                    return result
+            return None
         return None
-    if isinstance(value, dict):
-        for key in ("ip", "address", "gateway", "value"):
-            result = _extract_ip_from_value(value.get(key), version=version)
-            if result:
-                return result
-        return None
+
+    result = _extract(value)
+    if result:
+        return result
+    if version in (None, 6):
+        return fallback_link_local
     return None
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.unifi_gateway_refactored.monitor import SpeedtestRunner
 
+
 @pytest.fixture
 def mock_client():
     """Create mock UniFi client."""
@@ -20,12 +21,14 @@ def mock_client():
     client.get_speedtest_status.return_value = None
     return client
 
+
 @pytest.fixture
 def mock_coordinator():
     """Create mock coordinator."""
     coordinator = MagicMock()
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
+
 
 @pytest.fixture
 def mock_callback():
@@ -42,6 +45,7 @@ def run(coro) -> None:
         0.01,
     ):
         asyncio.run(coro)
+
 
 def test_speedtest_success(hass: HomeAssistant, mock_client, mock_coordinator, mock_callback):
     """Test successful speedtest run."""
@@ -73,6 +77,7 @@ def test_speedtest_success(hass: HomeAssistant, mock_client, mock_coordinator, m
     assert args["success"] is True
     assert args["error"] is None
 
+
 def test_speedtest_timeout(hass: HomeAssistant, mock_client, mock_coordinator, mock_callback):
     """Test speedtest timeout scenario."""
     runner = SpeedtestRunner(
@@ -94,6 +99,7 @@ def test_speedtest_timeout(hass: HomeAssistant, mock_client, mock_coordinator, m
     args = mock_callback.call_args[1]
     assert args["success"] is False
     assert "TimeoutError" in args["error"]
+
 
 def test_speedtest_failure_status(hass: HomeAssistant, mock_client, mock_coordinator, mock_callback):
     """Test speedtest failure status handling."""
@@ -118,6 +124,7 @@ def test_speedtest_failure_status(hass: HomeAssistant, mock_client, mock_coordin
     args = mock_callback.call_args[1]
     assert args["success"] is False
     assert "failure status" in args["error"]
+
 
 def test_concurrent_runs(hass: HomeAssistant, mock_client, mock_coordinator, mock_callback):
     """Test prevention of concurrent speedtest runs."""
@@ -147,6 +154,7 @@ def test_concurrent_runs(hass: HomeAssistant, mock_client, mock_coordinator, moc
 
     # Sprawdź czy tylko jeden test został wykonany
     assert mock_callback.call_count == 1
+
 
 def test_retry_mechanism(hass: HomeAssistant, mock_client, mock_coordinator, mock_callback):
     """Test speedtest retry mechanism."""


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
