### PR TITLE
Broaden urllib3 retry suppression and mute config flow connectivity log

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -216,13 +216,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=f"UniFi {data[CONF_HOST]}", data=data)
             except AuthError:
                 errors["base"] = "invalid_auth"
-            except ConnectivityError as err:
-                _LOGGER.error(
-                    "Connectivity issue while validating UniFi controller %s:%s: %s",
-                    data.get(CONF_HOST),
-                    data.get(CONF_PORT, DEFAULT_PORT),
-                    err,
-                )
+            except ConnectivityError:
                 errors["base"] = "cannot_connect"
             except APIError as err:
                 _LOGGER.error(


### PR DESCRIPTION
## Summary
- suppress retry spam for both urllib3 and the Requests vendored connectionpool loggers
- stop logging connectivity errors during the config flow to keep Home Assistant logs clean

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e01abfc07483279c89b7f3d3baaff3