### PR TITLE
V.0.6.5

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -216,13 +216,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=f"UniFi {data[CONF_HOST]}", data=data)
             except AuthError:
                 errors["base"] = "invalid_auth"
-            except ConnectivityError as err:
-                _LOGGER.error(
-                    "Connectivity issue while validating UniFi controller %s:%s: %s",
-                    data.get(CONF_HOST),
-                    data.get(CONF_PORT, DEFAULT_PORT),
-                    err,
-                )
+            except ConnectivityError:
                 errors["base"] = "cannot_connect"
             except APIError as err:
                 _LOGGER.error(


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
