### PR TITLE
Add WAN fallback IPv6 handling

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -186,6 +186,19 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                 "WAN link discovery required fallback derivation; derived=%s",
                 len(wan_links_raw),
             )
+            try:
+                ipv4, ipv6 = self._client.get_wan_ips_from_devices()
+            except APIError as err:
+                _LOGGER.debug("Failed to fetch WAN IPs from devices: %s", err)
+                ipv4 = ipv6 = None
+            if ipv4 or ipv6:
+                for wan in wan_links_raw:
+                    if not isinstance(wan, dict):
+                        continue
+                    if ipv4 and not wan.get("last_ipv4"):
+                        wan["last_ipv4"] = ipv4
+                    if ipv6 and not wan.get("last_ipv6"):
+                        wan["last_ipv6"] = ipv6
         wan_links: List[Dict[str, Any]] = []
         for link in wan_links_raw:
             link_id = link.get("id") or link.get("_id") or link.get("ifname")

--- a/tests/stubs/homeassistant/const.py
+++ b/tests/stubs/homeassistant/const.py
@@ -11,6 +11,7 @@ class UnitOfTime(Enum):
 
 
 TIME_MILLISECONDS = UnitOfTime.MILLISECONDS
+STATE_UNKNOWN = "unknown"
 
 
 class Platform(str, Enum):
@@ -21,4 +22,4 @@ class Platform(str, Enum):
     SENSOR = "sensor"
 
 
-__all__ = ["Platform", "UnitOfTime", "TIME_MILLISECONDS"]
+__all__ = ["Platform", "UnitOfTime", "TIME_MILLISECONDS", "STATE_UNKNOWN"]


### PR DESCRIPTION
## Summary
- add a UniFi client helper to read WAN IPv4/IPv6 from stat/device payloads
- enrich derived WAN link data with cached IP addresses during fallback discovery
- prefer IPv6 for the WAN IP sensor when IPv6 is enabled and extend IPv6 sensor tests

## Testing
- ruff check
- flake8
- mypy .
- bandit -r .
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68e028962fd883278d837955da01562d