### PR TITLE
V.0.6.5

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -186,6 +186,19 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                 "WAN link discovery required fallback derivation; derived=%s",
                 len(wan_links_raw),
             )
+            try:
+                ipv4, ipv6 = self._client.get_wan_ips_from_devices()
+            except APIError as err:
+                _LOGGER.debug("Failed to fetch WAN IPs from devices: %s", err)
+                ipv4 = ipv6 = None
+            if ipv4 or ipv6:
+                for wan in wan_links_raw:
+                    if not isinstance(wan, dict):
+                        continue
+                    if ipv4 and not wan.get("last_ipv4"):
+                        wan["last_ipv4"] = ipv4
+                    if ipv6 and not wan.get("last_ipv6"):
+                        wan["last_ipv6"] = ipv6
         wan_links: List[Dict[str, Any]] = []
         for link in wan_links_raw:
             link_id = link.get("id") or link.get("_id") or link.get("ifname")

--- a/tests/stubs/homeassistant/const.py
+++ b/tests/stubs/homeassistant/const.py
@@ -11,6 +11,7 @@ class UnitOfTime(Enum):
 
 
 TIME_MILLISECONDS = UnitOfTime.MILLISECONDS
+STATE_UNKNOWN = "unknown"
 
 
 class Platform(str, Enum):
@@ -21,4 +22,4 @@ class Platform(str, Enum):
     SENSOR = "sensor"
 
 
-__all__ = ["Platform", "UnitOfTime", "TIME_MILLISECONDS"]
+__all__ = ["Platform", "UnitOfTime", "TIME_MILLISECONDS", "STATE_UNKNOWN"]


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
