### PR TITLE
Log UI Cloud hosts endpoint usage

### DIFF
--- a/custom_components/unifi_gateway_refactored/cloud_client.py
+++ b/custom_components/unifi_gateway_refactored/cloud_client.py
@@ -1,0 +1,166 @@
+"""Client for the UniFi UI Cloud API used to retrieve WAN IPv6 addresses."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from .const import UI_HOSTS_URL
+
+
+class UiCloudError(Exception):
+    """Base exception for UI Cloud API failures."""
+
+
+class UiCloudAuthError(UiCloudError):
+    """Raised when authentication with the UI Cloud API fails."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"UI Cloud API authentication failed (status={status})")
+        self.status = status
+
+
+class UiCloudRateLimitError(UiCloudError):
+    """Raised when the UI Cloud API responds with HTTP 429."""
+
+    def __init__(self, retry_after: float | None) -> None:
+        message = "UI Cloud API rate limited"
+        if retry_after is not None:
+            message = f"{message}; retry in {retry_after:.1f}s"
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class UiCloudRequestError(UiCloudError):
+    """Raised when the UI Cloud API request ultimately fails."""
+
+
+@dataclass(slots=True)
+class UiCloudClient:
+    """Thin asynchronous client for the UniFi UI Cloud API."""
+
+    session: aiohttp.ClientSession
+    api_key: str
+
+    async def fetch_hosts(self) -> Dict[str, Any]:
+        """Return the raw hosts payload from the UI Cloud API."""
+
+        url = UI_HOSTS_URL
+        headers = {"Accept": "application/json", "X-API-Key": self.api_key}
+        timeouts = aiohttp.ClientTimeout(total=10)
+        backoffs = (0.0, 0.5, 1.0, 2.0)
+        last_error: UiCloudRequestError | None = None
+
+        for attempt, delay in enumerate(backoffs, start=1):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                resp = await self.session.get(url, headers=headers, timeout=timeouts)
+            except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+                last_error = UiCloudRequestError("Error communicating with UI Cloud API")
+                last_error.__cause__ = err
+                continue
+
+            async with resp:
+                status = resp.status
+                if status == 429:
+                    retry_after = self._parse_retry_after(resp.headers.get("Retry-After"))
+                    if attempt == len(backoffs):
+                        raise UiCloudRateLimitError(retry_after)
+                    await asyncio.sleep(retry_after if retry_after is not None else 5.0)
+                    continue
+                if status in (401, 403):
+                    raise UiCloudAuthError(status)
+                if 500 <= status:
+                    last_error = UiCloudRequestError(
+                        f"UI Cloud API server error (status={status})"
+                    )
+                    continue
+                if status >= 400:
+                    raise UiCloudRequestError(
+                        f"Unexpected UI Cloud API response (status={status})"
+                    )
+
+                try:
+                    return await resp.json()
+                except aiohttp.ContentTypeError as err:
+                    last_error = UiCloudRequestError("Invalid JSON response")
+                    last_error.__cause__ = err
+                    continue
+
+        if last_error is None:
+            last_error = UiCloudRequestError("Failed to fetch UI Cloud hosts")
+        raise last_error
+
+    @staticmethod
+    def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        return max(0.0, parsed)
+
+    async def fetch_ipv6_for_mac(self, target_mac: str) -> Optional[str]:
+        """Return the IPv6 address for the provided WAN MAC."""
+
+        normalized_mac = _normalize_mac(target_mac)
+        if not normalized_mac:
+            return None
+
+        payload = await self.fetch_hosts()
+        for console in payload.get("data", []):
+            reported = console.get("reportedState") or {}
+            wans = reported.get("wans") or []
+            for wan in wans:
+                if not isinstance(wan, dict):
+                    continue
+                mac = _normalize_mac(wan.get("mac"))
+                if not mac or mac != normalized_mac:
+                    continue
+                if not _wan_candidate_enabled(wan):
+                    continue
+                ipv6 = wan.get("ipv6")
+                if isinstance(ipv6, str) and ipv6.strip():
+                    return ipv6.strip()
+            # If the console doesn't contain the target MAC continue searching.
+        return None
+
+
+def _wan_candidate_enabled(wan: Dict[str, Any]) -> bool:
+    if not wan.get("enabled", True):
+        return False
+    wan_type = str(wan.get("type") or "").upper()
+    if wan_type and wan_type not in {"WAN", "WAN1", "PRIMARY"}:
+        return False
+    return True
+
+
+def _normalize_mac(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    hex_chars = [char for char in value if char.isalnum()]
+    cleaned = "".join(hex_chars)
+    if len(cleaned) != 12:
+        return None
+    try:
+        int(cleaned, 16)
+    except ValueError:
+        return None
+    pairs = [cleaned[i:i + 2] for i in range(0, 12, 2)]
+    return ":".join(pairs).lower()
+
+
+__all__ = [
+    "UiCloudClient",
+    "UiCloudError",
+    "UiCloudAuthError",
+    "UiCloudRateLimitError",
+    "UiCloudRequestError",
+]

--- a/custom_components/unifi_gateway_refactored/const.py
+++ b/custom_components/unifi_gateway_refactored/const.py
@@ -18,6 +18,7 @@ LEGACY_CONF_SPEEDTEST_INTERVAL_MIN = "speedtest_interval_minutes"
 CONF_SPEEDTEST_ENTITIES = "speedtest_entities"
 CONF_WIFI_GUEST = "wifi_guest"
 CONF_WIFI_IOT = "wifi_iot"
+CONF_UI_API_KEY = "ui_api_key"
 
 DEFAULT_PORT = 443
 DEFAULT_SITE = "default"
@@ -43,3 +44,5 @@ ATTR_REASON = "reason"
 ATTR_ENTITY_IDS = "entity_ids"
 ATTR_DURATION_MS = "duration_ms"
 ATTR_ERROR = "error"
+
+UI_HOSTS_URL = "https://api.ui.com/v1/hosts"

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import logging
+import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .cloud_client import UiCloudAuthError, UiCloudClient, UiCloudError, UiCloudRateLimitError
+from .const import DOMAIN, UI_HOSTS_URL
 from .unifi_client import APIError, ConnectivityError, UniFiOSClient
 
 
@@ -45,8 +47,12 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
         client: UniFiOSClient,
         *,
         speedtest_interval: int | None = None,
+        ui_cloud_client: UiCloudClient | None = None,
     ) -> None:
         self._client = client
+        self._ui_cloud_client = ui_cloud_client
+        self._wan_ipv6_cache: dict[str, tuple[float, str]] = {}
+        self._cloud_cache_ttl = 300.0
         self._speedtest_interval = self._sanitize_speedtest_interval(speedtest_interval)
         super().__init__(
             hass,
@@ -54,6 +60,11 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             name=f"{DOMAIN} data",
             update_interval=timedelta(seconds=15),
         )
+        if self._ui_cloud_client is not None:
+            _LOGGER.info(
+                "Using UI Cloud API for WAN IPv6 via %s",
+                UI_HOSTS_URL,
+            )
 
     @staticmethod
     def _sanitize_speedtest_interval(value: int | None) -> int:
@@ -103,13 +114,297 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             return dt_utc.timestamp()
         return None
 
+    async def _merge_wan_ipv6_from_cloud(self, data: UniFiGatewayData) -> None:
+        if not data or not data.wan_links:
+            return
+
+        mapping: dict[str, str] = {}
+        if self._ui_cloud_client is None:
+            return
+        try:
+            payload = await self._ui_cloud_client.fetch_hosts()
+        except UiCloudAuthError as err:
+            _LOGGER.warning(
+                "UI Cloud API authentication failed while fetching WAN IPv6 (status=%s)",
+                err.status,
+            )
+        except UiCloudRateLimitError as err:
+            retry_desc = (
+                f"{err.retry_after:.1f}s" if err.retry_after is not None else "unknown"
+            )
+            _LOGGER.warning(
+                "UI Cloud API rate limited while fetching WAN IPv6 (retry_in=%s)",
+                retry_desc,
+            )
+        except UiCloudError as err:
+            _LOGGER.error("Failed to fetch WAN IPv6 from UI Cloud API: %s", err)
+        else:
+            if isinstance(payload, Mapping):
+                mapping = self._extract_ipv6_mapping(payload)
+            else:
+                _LOGGER.debug(
+                    "UI Cloud API returned unexpected payload type: %s",
+                    type(payload),
+                )
+
+        now = time.monotonic()
+        self._apply_wan_ipv6_updates(data, mapping, now)
+
+    @staticmethod
+    def _extract_ipv6_mapping(payload: Mapping[str, Any]) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        data_list = payload.get("data")
+        if not isinstance(data_list, list):
+            return mapping
+        for console in data_list:
+            if not isinstance(console, Mapping):
+                continue
+            reported = console.get("reportedState")
+            if not isinstance(reported, Mapping):
+                continue
+            wans = reported.get("wans")
+            if not isinstance(wans, list):
+                continue
+            for wan in wans:
+                if not isinstance(wan, Mapping):
+                    continue
+                if not UniFiGatewayDataUpdateCoordinator._wan_candidate_enabled(wan):
+                    continue
+                mac = UniFiGatewayDataUpdateCoordinator._normalize_mac(wan.get("mac"))
+                if not mac or mac in mapping:
+                    continue
+                ipv6 = wan.get("ipv6")
+                if isinstance(ipv6, str):
+                    ipv6_clean = ipv6.strip()
+                    if ipv6_clean:
+                        mapping[mac] = ipv6_clean
+        return mapping
+
+    def _apply_wan_ipv6_updates(
+        self,
+        data: UniFiGatewayData,
+        mapping: dict[str, str],
+        now: float,
+    ) -> None:
+        if not data.wan_links:
+            return
+
+        health_lookup = self._build_health_lookup(data.wan_health)
+
+        for link in data.wan_links:
+            if not isinstance(link, dict):
+                continue
+
+            mac, health_record = self._resolve_wan_mac(link, health_lookup)
+            if not mac:
+                continue
+
+            cached_value: Optional[str] = None
+            cache_entry = self._wan_ipv6_cache.get(mac)
+            if cache_entry:
+                ts, cached = cache_entry
+                if (now - ts) <= self._cloud_cache_ttl:
+                    cached_value = cached
+                else:
+                    self._wan_ipv6_cache.pop(mac, None)
+
+            if mac in mapping:
+                ipv6_value = mapping[mac]
+                link["last_ipv6"] = ipv6_value
+                if not link.get("wan_ipv6"):
+                    link["wan_ipv6"] = ipv6_value
+                if isinstance(health_record, dict):
+                    if not health_record.get("last_ipv6"):
+                        health_record["last_ipv6"] = ipv6_value
+                    if not health_record.get("wan_ipv6"):
+                        health_record["wan_ipv6"] = ipv6_value
+                self._wan_ipv6_cache[mac] = (now, ipv6_value)
+                continue
+
+            if cached_value and not link.get("last_ipv6"):
+                link["last_ipv6"] = cached_value
+                if not link.get("wan_ipv6"):
+                    link["wan_ipv6"] = cached_value
+                if isinstance(health_record, dict):
+                    if not health_record.get("last_ipv6"):
+                        health_record["last_ipv6"] = cached_value
+                    if not health_record.get("wan_ipv6"):
+                        health_record["wan_ipv6"] = cached_value
+
+    @staticmethod
+    def _build_health_lookup(records: List[Dict[str, Any]]) -> dict[str, Dict[str, Any]]:
+        lookup: dict[str, Dict[str, Any]] = {}
+        keys = ("id", "_id", "ifname", "name", "wan_name", "display_name")
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            for key in keys:
+                if key not in record:
+                    continue
+                for identifier in UniFiGatewayDataUpdateCoordinator._normalized_identifiers(
+                    record.get(key)
+                ):
+                    if identifier not in lookup:
+                        lookup[identifier] = record
+        return lookup
+
+    def _resolve_wan_mac(
+        self,
+        link: Mapping[str, Any],
+        health_lookup: dict[str, Dict[str, Any]],
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+        identifiers = self._collect_link_identifiers(link)
+        health_record: Optional[Dict[str, Any]] = None
+        for identifier in identifiers:
+            if identifier in health_lookup:
+                health_record = health_lookup[identifier]
+                break
+
+        mac = self._extract_mac_from_mapping(link)
+        if mac:
+            if health_record is None:
+                for identifier in identifiers:
+                    if identifier in health_lookup:
+                        health_record = health_lookup[identifier]
+                        break
+            return mac, health_record
+
+        if health_record is not None:
+            mac = self._extract_mac_from_mapping(health_record)
+            if mac:
+                return mac, health_record
+
+        return None, health_record
+
+    @staticmethod
+    def _collect_link_identifiers(link: Mapping[str, Any]) -> set[str]:
+        identifiers: set[str] = set()
+        keys = (
+            "id",
+            "_id",
+            "ifname",
+            "interface",
+            "wan_port",
+            "port",
+            "display_name",
+            "wan_name",
+            "name",
+        )
+        for key in keys:
+            if key not in link:
+                continue
+            identifiers.update(
+                UniFiGatewayDataUpdateCoordinator._normalized_identifiers(
+                    link.get(key)
+                )
+            )
+        return identifiers
+
+    @staticmethod
+    def _normalized_identifiers(value: Any) -> set[str]:
+        results: set[str] = set()
+        if value in (None, ""):
+            return results
+        if isinstance(value, str):
+            text = value.strip().lower()
+        else:
+            text = str(value).strip().lower()
+        if not text:
+            return results
+        results.add(text)
+        collapsed = text.replace(" ", "")
+        if collapsed:
+            results.add(collapsed)
+        return results
+
+    @staticmethod
+    def _extract_mac_from_mapping(mapping: Mapping[str, Any]) -> Optional[str]:
+        mac_keys = (
+            "mac",
+            "mac_address",
+            "macAddress",
+            "primary_mac",
+            "primaryMac",
+            "gateway_mac",
+            "gatewayMac",
+            "gw_mac",
+            "gwMac",
+            "wan_mac",
+            "wanMac",
+            "wan_macaddr",
+            "wanMacAddr",
+            "wan_gw_mac",
+            "wanGwMac",
+            "wanGwMacAddr",
+            "device_mac",
+            "deviceMac",
+            "port_mac",
+            "portMac",
+            "if_mac",
+            "ifMac",
+            "wan_if_mac",
+            "wanIfMac",
+            "remote_mac",
+            "remoteMac",
+            "uplink_mac",
+            "uplinkMac",
+        )
+        for key in mac_keys:
+            normalized = UniFiGatewayDataUpdateCoordinator._normalize_mac(
+                mapping.get(key)
+            )
+            if normalized:
+                return normalized
+        uplink = mapping.get("uplink")
+        if isinstance(uplink, Mapping):
+            nested = UniFiGatewayDataUpdateCoordinator._extract_mac_from_mapping(uplink)
+            if nested:
+                return nested
+        return None
+
+    @staticmethod
+    def _normalize_mac(value: Any) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        if not isinstance(value, str):
+            value = str(value)
+        cleaned = re.sub(r"[^0-9A-Fa-f]", "", value)
+        if len(cleaned) != 12:
+            return None
+        try:
+            int(cleaned, 16)
+        except ValueError:
+            return None
+        parts = [cleaned[i:i + 2] for i in range(0, 12, 2)]
+        return ":".join(parts).lower()
+
+    @staticmethod
+    def _wan_candidate_enabled(wan: Mapping[str, Any]) -> bool:
+        if wan.get("enabled") is False:
+            return False
+        wan_type = str(wan.get("type") or "").strip().upper()
+        if wan_type and wan_type not in {"WAN", "WAN1", "PRIMARY"}:
+            return False
+        return True
+
     async def _async_update_data(self) -> UniFiGatewayData:
         try:
-            return await self.hass.async_add_executor_job(
+            data = await self.hass.async_add_executor_job(
                 self._fetch_data,
             )
         except (ConnectivityError, APIError) as err:
             raise UpdateFailed(str(err)) from err
+
+        if self._ui_cloud_client is not None and data:
+            try:
+                await self._merge_wan_ipv6_from_cloud(data)
+            except Exception as err:  # pragma: no cover - defensive logging
+                _LOGGER.exception(
+                    "Unexpected error while merging WAN IPv6 data from UI Cloud API: %s",
+                    err,
+                )
+
+        return data
 
     def _fetch_data(self) -> UniFiGatewayData:
         """Fetch data with improved VPN and speedtest handling."""
@@ -186,24 +481,25 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                 len(wan_links_raw),
             )
 
+        ipv4: Optional[str] = None
         try:
-            ipv4, ipv6 = self._client.get_wan_ips_from_devices()
+            wan_ips = self._client.get_wan_ips_from_devices()
         except Exception as err:  # pragma: no cover - defensive guard for API quirks
-            ipv4 = ipv6 = None
             _LOGGER.debug("WAN IPs from devices unavailable: %s", err)
+        else:
+            if isinstance(wan_ips, (list, tuple)) and wan_ips:
+                ipv4_candidate = wan_ips[0]
+                if isinstance(ipv4_candidate, str) and ipv4_candidate:
+                    ipv4 = ipv4_candidate
 
-        if wan_links_raw and (ipv4 or ipv6):
+        if wan_links_raw and ipv4:
             for wan in wan_links_raw:
                 if isinstance(wan, dict):
                     if ipv4 and not wan.get("last_ipv4"):
                         wan["last_ipv4"] = ipv4
-                    if ipv6 and not wan.get("last_ipv6"):
-                        wan["last_ipv6"] = ipv6
                 else:
                     if ipv4 and not getattr(wan, "last_ipv4", None):
                         setattr(wan, "last_ipv4", ipv4)
-                    if ipv6 and not getattr(wan, "last_ipv6", None):
-                        setattr(wan, "last_ipv6", ipv6)
         wan_links: List[Dict[str, Any]] = []
         for link in wan_links_raw:
             link_id = link.get("id") or link.get("_id") or link.get("ifname")

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -19,7 +19,8 @@
     "custom_components.unifi_gateway_refactored",
     "custom_components.unifi_gateway_refactored.coordinator",
     "custom_components.unifi_gateway_refactored.monitor",
-    "custom_components.unifi_gateway_refactored.unifi_client"
+    "custom_components.unifi_gateway_refactored.unifi_client",
+    "custom_components.unifi_gateway_refactored.cloud_client"
   ],
   "logo": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/logo.svg",
   "icon": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/icon.svg"

--- a/custom_components/unifi_gateway_refactored/sensor.py
+++ b/custom_components/unifi_gateway_refactored/sensor.py
@@ -3358,7 +3358,7 @@ def _extract_ip_from_value(value: Any, *, version: Optional[int] = None) -> Opti
             closing = text.find("]")
             if closing != -1:
                 inside = text[1:closing]
-                remainder = text[closing + 1 :]
+                remainder = text[closing + 1:]
                 if remainder.startswith(":") and remainder[1:].isdigit():
                     remainder = ""
                 return inside + remainder

--- a/custom_components/unifi_gateway_refactored/strings.json
+++ b/custom_components/unifi_gateway_refactored/strings.json
@@ -21,6 +21,7 @@
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)",
+          "ui_api_key": "UI Cloud API key",
           "wifi_guest": "Guest WiFi SSID",
           "wifi_iot": "IoT WiFi SSID"
         }
@@ -29,6 +30,9 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Cannot connect to UniFi host.",
+      "invalid_api_key": "Invalid UI Cloud API key.",
+      "api_rate_limited": "UI Cloud API rate limited. Try again later.",
+      "api_unavailable": "UI Cloud API unavailable.",
       "missing_auth": "Provide a username and password.",
       "unknown": "Unknown error."
     }
@@ -49,6 +53,7 @@
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)",
+          "ui_api_key": "UI Cloud API key",
           "wifi_guest": "Guest WiFi SSID",
           "wifi_iot": "IoT WiFi SSID"
         }
@@ -57,6 +62,9 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Cannot connect to UniFi host.",
+      "invalid_api_key": "Invalid UI Cloud API key.",
+      "api_rate_limited": "UI Cloud API rate limited. Try again later.",
+      "api_unavailable": "UI Cloud API unavailable.",
       "missing_auth": "Provide a username and password.",
       "unknown": "Unknown error."
     }

--- a/custom_components/unifi_gateway_refactored/translations/en.json
+++ b/custom_components/unifi_gateway_refactored/translations/en.json
@@ -21,6 +21,7 @@
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)",
+          "ui_api_key": "UI Cloud API key",
           "wifi_guest": "Guest WiFi SSID",
           "wifi_iot": "IoT WiFi SSID"
         }
@@ -29,6 +30,9 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Cannot connect to UniFi host.",
+      "invalid_api_key": "Invalid UI Cloud API key.",
+      "api_rate_limited": "UI Cloud API rate limited. Try again later.",
+      "api_unavailable": "UI Cloud API unavailable.",
       "missing_auth": "Provide a username and password.",
       "unknown": "Unknown error."
     }
@@ -49,6 +53,7 @@
           "timeout": "HTTP timeout (seconds)",
           "speedtest_interval": "Speedtest interval (minutes)",
           "speedtest_entities": "Speedtest entity IDs (comma separated)",
+          "ui_api_key": "UI Cloud API key",
           "wifi_guest": "Guest WiFi SSID",
           "wifi_iot": "IoT WiFi SSID"
         }
@@ -57,6 +62,9 @@
     "error": {
       "invalid_auth": "Invalid credentials.",
       "cannot_connect": "Cannot connect to UniFi host.",
+      "invalid_api_key": "Invalid UI Cloud API key.",
+      "api_rate_limited": "UI Cloud API rate limited. Try again later.",
+      "api_unavailable": "UI Cloud API unavailable.",
       "missing_auth": "Provide a username and password.",
       "unknown": "Unknown error."
     }

--- a/custom_components/unifi_gateway_refactored/translations/pl.json
+++ b/custom_components/unifi_gateway_refactored/translations/pl.json
@@ -21,6 +21,7 @@
           "timeout": "Limit czasu żądania HTTP (sekundy)",
           "speedtest_interval": "Interwał speedtestu (minuty)",
           "speedtest_entities": "Identyfikatory encji speedtestu (oddzielone przecinkami)",
+          "ui_api_key": "Klucz API UI Cloud",
           "wifi_guest": "SSID sieci WiFi dla gości",
           "wifi_iot": "SSID sieci WiFi dla IoT"
         }
@@ -29,6 +30,9 @@
     "error": {
       "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
       "cannot_connect": "Nie można połączyć się z kontrolerem UniFi.",
+      "invalid_api_key": "Nieprawidłowy klucz API UI Cloud.",
+      "api_rate_limited": "UI Cloud API ograniczyło zapytania. Spróbuj ponownie później.",
+      "api_unavailable": "UI Cloud API jest niedostępne.",
       "unknown": "Nieznany błąd."
     }
   },
@@ -48,6 +52,7 @@
           "timeout": "Limit czasu żądania HTTP (sekundy)",
           "speedtest_interval": "Interwał speedtestu (minuty)",
           "speedtest_entities": "Identyfikatory encji speedtestu (oddzielone przecinkami)",
+          "ui_api_key": "Klucz API UI Cloud",
           "wifi_guest": "SSID sieci WiFi dla gości",
           "wifi_iot": "SSID sieci WiFi dla IoT"
         }
@@ -56,6 +61,9 @@
     "error": {
       "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
       "cannot_connect": "Nie można połączyć się z kontrolerem UniFi.",
+      "invalid_api_key": "Nieprawidłowy klucz API UI Cloud.",
+      "api_rate_limited": "UI Cloud API ograniczyło zapytania. Spróbuj ponownie później.",
+      "api_unavailable": "UI Cloud API jest niedostępne.",
       "unknown": "Nieznany błąd."
     }
   },

--- a/tests/stubs/aiohttp/__init__.py
+++ b/tests/stubs/aiohttp/__init__.py
@@ -1,0 +1,35 @@
+"""Minimal aiohttp stub for unit tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ClientError(Exception):
+    """Base client error."""
+
+
+class ContentTypeError(ClientError):
+    """Raised when JSON decoding fails."""
+
+
+class ClientTimeout:
+    def __init__(self, total: float | None = None) -> None:
+        self.total = total
+
+
+class ClientSession:
+    def __init__(self, timeout: ClientTimeout | None = None) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> "ClientSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def get(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - network disabled in tests
+        raise RuntimeError("aiohttp client session is not available in tests")
+
+
+__all__ = ["ClientError", "ContentTypeError", "ClientTimeout", "ClientSession"]

--- a/tests/stubs/homeassistant/core.py
+++ b/tests/stubs/homeassistant/core.py
@@ -14,6 +14,18 @@ class _ConfigEntriesManager:
     async def async_unload_platforms(self, entry: Any, platforms: Any) -> bool:
         return True
 
+    async def async_update_entry(
+        self,
+        entry: Any,
+        *,
+        data: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        if data is not None:
+            entry.data = data
+        if options is not None:
+            entry.options = options
+
 
 class EventBus:
     """Very small async event bus recorder."""

--- a/tests/stubs/homeassistant/helpers/aiohttp_client.py
+++ b/tests/stubs/homeassistant/helpers/aiohttp_client.py
@@ -1,0 +1,18 @@
+"""Stub for Home Assistant aiohttp client helper used in tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def async_get_clientsession(_hass: Any, *, verify_ssl: bool | None = None):
+    """Return a simple stub object for the aiohttp client session."""
+
+    class _StubSession:
+        async def get(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - unused in tests
+            raise RuntimeError("HTTP client not available in stub")
+
+    return _StubSession()
+
+
+__all__ = ["async_get_clientsession"]

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -1,0 +1,192 @@
+"""Tests for the UniFi UI Cloud client helper."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, cast
+
+import pytest
+
+from aiohttp import ClientError, ClientSession
+from custom_components.unifi_gateway_refactored.cloud_client import (
+    UiCloudAuthError,
+    UiCloudClient,
+    UiCloudError,
+    UiCloudRateLimitError,
+    UiCloudRequestError,
+)
+from custom_components.unifi_gateway_refactored.const import UI_HOSTS_URL
+
+
+class DummyResponse:
+    def __init__(self, status: int, payload: Any = None, headers: dict[str, str] | None = None) -> None:
+        self.status = status
+        self._payload = payload
+        self.headers = headers or {}
+
+    async def __aenter__(self) -> "DummyResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def json(self) -> Any:
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, responses: List[DummyResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[str] = []
+
+    async def get(self, url: str, *, headers: dict[str, str] | None = None, timeout=None) -> DummyResponse:
+        self.requests.append(url)
+        if not self._responses:
+            raise RuntimeError("No more responses queued")
+        return self._responses.pop(0)
+
+
+class FailingSession:
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.calls = 0
+        self.urls: list[str] = []
+
+    async def get(self, url: str, *, headers: dict[str, str] | None = None, timeout=None) -> DummyResponse:
+        self.calls += 1
+        self.urls.append(url)
+        raise self._error
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def test_fetch_ipv6_for_mac_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    payload = {
+        "data": [
+            {
+                "reportedState": {
+                    "wans": [
+                        {
+                            "mac": "78:45:58:D0:95:75",
+                            "ipv6": "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe",
+                            "enabled": True,
+                            "type": "WAN",
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    session = DummySession([DummyResponse(200, payload)])
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    ipv6 = asyncio.run(client.fetch_ipv6_for_mac("78:45:58:D0:95:75"))
+
+    assert ipv6 == "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe"
+    assert session.requests == [UI_HOSTS_URL]
+
+
+def test_fetch_ipv6_for_mac_returns_none_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    payload = {
+        "data": [
+            {
+                "reportedState": {
+                    "wans": [
+                        {
+                            "mac": "78:45:58:d0:95:75",
+                            "ipv6": "",
+                            "enabled": True,
+                            "type": "WAN",
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    session = DummySession([DummyResponse(200, payload)])
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    ipv6 = asyncio.run(client.fetch_ipv6_for_mac("00:00:00:00:00:00"))
+
+    assert ipv6 is None
+    assert session.requests == [UI_HOSTS_URL]
+
+
+def test_fetch_hosts_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    session = DummySession([DummyResponse(401, {})])
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    with pytest.raises(UiCloudAuthError):
+        asyncio.run(client.fetch_hosts())
+    assert session.requests == [UI_HOSTS_URL]
+
+
+def test_fetch_hosts_rate_limited(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    responses = [
+        DummyResponse(429, {}, {"Retry-After": "1.5"}),
+        DummyResponse(429, {}, {"Retry-After": "1.5"}),
+        DummyResponse(429, {}, {"Retry-After": "1.5"}),
+        DummyResponse(429, {}, {"Retry-After": "1.5"}),
+    ]
+    session = DummySession(responses)
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    with pytest.raises(UiCloudRateLimitError):
+        asyncio.run(client.fetch_hosts())
+
+    assert sleep_calls == [1.5, 0.5, 1.5, 1.0, 1.5, 2.0]
+    assert session.requests == [UI_HOSTS_URL] * 4
+
+
+def test_fetch_hosts_retries_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    payload: dict[str, Any] = {"data": []}
+    session = DummySession([DummyResponse(500, {}), DummyResponse(200, payload)])
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    result = asyncio.run(client.fetch_hosts())
+
+    assert result == payload
+    assert len(session.requests) == 2
+    assert session.requests == [UI_HOSTS_URL, UI_HOSTS_URL]
+
+
+def test_fetch_hosts_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    session = DummySession(
+        [
+            DummyResponse(502, {}),
+            DummyResponse(502, {}),
+            DummyResponse(502, {}),
+            DummyResponse(502, {}),
+        ]
+    )
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    with pytest.raises(UiCloudError):
+        asyncio.run(client.fetch_hosts())
+    assert session.requests == [UI_HOSTS_URL] * 4
+
+
+def test_fetch_hosts_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    error = ClientError("boom")
+    session = FailingSession(error)
+    client = UiCloudClient(cast(ClientSession, session), "secret")
+
+    with pytest.raises(UiCloudRequestError):
+        asyncio.run(client.fetch_hosts())
+
+    assert session.calls == 4
+    assert session.urls == [UI_HOSTS_URL] * 4

--- a/tests/test_coordinator_cloud_ipv6.py
+++ b/tests/test_coordinator_cloud_ipv6.py
@@ -1,0 +1,165 @@
+"""Tests for merging WAN IPv6 data from the UI Cloud API."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, cast
+
+from custom_components.unifi_gateway_refactored.cloud_client import UiCloudError, UiCloudRateLimitError
+from custom_components.unifi_gateway_refactored.coordinator import (
+    UniFiGatewayData,
+    UniFiGatewayDataUpdateCoordinator,
+)
+
+
+class DummyClient:
+    def instance_key(self) -> str:
+        return "dummy"
+
+
+class DummyCloudClient:
+    def __init__(self, payload: Dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self._payload = payload
+        self._error = error
+        self.calls = 0
+
+    async def fetch_hosts(self) -> Dict[str, Any]:
+        self.calls += 1
+        if self._error:
+            raise self._error
+        return self._payload or {}
+
+
+class DummyCoordinator(UniFiGatewayDataUpdateCoordinator):
+    def __init__(
+        self,
+        hass,
+        data: UniFiGatewayData,
+        cloud_client: DummyCloudClient,
+    ) -> None:
+        self._test_data = data
+        super().__init__(
+            hass,
+            cast(Any, DummyClient()),
+            ui_cloud_client=cast(Any, cloud_client),
+        )
+
+    def _fetch_data(self) -> UniFiGatewayData:
+        return self._test_data
+
+
+def _build_data(mac: str) -> UniFiGatewayData:
+    return UniFiGatewayData(
+        controller={},
+        wan_links=[{"id": "wan1", "name": "WAN", "mac": mac}],
+        wan_health=[{"id": "wan1"}],
+    )
+
+
+def test_coordinator_applies_cloud_ipv6(hass) -> None:
+    mac = "78:45:58:D0:95:75"
+    payload = {
+        "data": [
+            {
+                "reportedState": {
+                    "wans": [
+                        {
+                            "mac": mac,
+                            "ipv6": "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe",
+                            "enabled": True,
+                            "type": "WAN",
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    cloud_client = DummyCloudClient(payload)
+    data = _build_data(mac)
+    coordinator = DummyCoordinator(hass, data, cloud_client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    link = result.wan_links[0]
+    assert link["last_ipv6"] == "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe"
+    assert coordinator._wan_ipv6_cache["78:45:58:d0:95:75"][1] == "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe"
+    health = result.wan_health[0]
+    assert health["wan_ipv6"] == "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe"
+
+
+def test_coordinator_uses_cache_on_error(hass, caplog) -> None:
+    mac = "78:45:58:D0:95:75"
+    error = UiCloudError("boom")
+    cloud_client = DummyCloudClient(error=error)
+    data = _build_data(mac)
+    coordinator = DummyCoordinator(hass, data, cloud_client)
+    normalized_mac = "78:45:58:d0:95:75"
+    coordinator._wan_ipv6_cache[normalized_mac] = (time.monotonic() - 10, "2001:db8::1")
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    link = result.wan_links[0]
+    assert link["last_ipv6"] == "2001:db8::1"
+    assert "Failed to fetch WAN IPv6 from UI Cloud API" in caplog.text
+
+
+def test_coordinator_ignores_expired_cache(hass) -> None:
+    mac = "78:45:58:D0:95:75"
+    cloud_client = DummyCloudClient(error=UiCloudError("down"))
+    data = _build_data(mac)
+    coordinator = DummyCoordinator(hass, data, cloud_client)
+    normalized_mac = "78:45:58:d0:95:75"
+    coordinator._wan_ipv6_cache[normalized_mac] = (time.monotonic() - 600, "2001:db8::2")
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    link = result.wan_links[0]
+    assert link.get("last_ipv6") is None
+
+
+def test_coordinator_logs_rate_limit_warning(hass, caplog) -> None:
+    mac = "78:45:58:D0:95:75"
+    error = UiCloudRateLimitError(3.0)
+    cloud_client = DummyCloudClient(error=error)
+    data = _build_data(mac)
+    coordinator = DummyCoordinator(hass, data, cloud_client)
+    normalized_mac = "78:45:58:d0:95:75"
+    coordinator._wan_ipv6_cache[normalized_mac] = (time.monotonic() - 5, "2001:db8::3")
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert "retry_in=3.0s" in caplog.text
+    assert result.wan_links[0]["last_ipv6"] == "2001:db8::3"
+
+
+def test_coordinator_extracts_mac_from_camel_case_keys(hass) -> None:
+    mac = "78:45:58:D0:95:75"
+    payload = {
+        "data": [
+            {
+                "reportedState": {
+                    "wans": [
+                        {
+                            "mac": mac,
+                            "ipv6": "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe",
+                            "enabled": True,
+                            "type": "PRIMARY",
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    cloud_client = DummyCloudClient(payload)
+    data = UniFiGatewayData(
+        controller={},
+        wan_links=[{"id": "wan1", "name": "WAN"}],
+        wan_health=[{"id": "wan1", "gwMac": mac}],
+    )
+    coordinator = DummyCoordinator(hass, data, cloud_client)
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    link = result.wan_links[0]
+    assert link["last_ipv6"] == "2a00:c020:40fe:37f1:4402:b7a2:4cd3:e8fe"


### PR DESCRIPTION
## Summary
- log the fixed https://api.ui.com/v1/hosts endpoint when enabling UI Cloud WAN IPv6 fetching
- tidy the UI Cloud client module formatting to satisfy flake8

## Testing
- `ruff check`
- `flake8 --max-line-length=120 custom_components/unifi_gateway_refactored tests`
- `mypy --ignore-missing-imports custom_components/unifi_gateway_refactored tests`
- `bandit -r custom_components/unifi_gateway_refactored -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e049072f948327b2c057850370de09