### PR TITLE
V.0.6.8

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -263,6 +263,8 @@ def test_missing_api_key_uses_local_ipv6(hass) -> None:
     attrs = result.wan_attrs
     assert attrs["last_ipv6"] == "2001:db8::10"
     assert attrs["source"] == "controller"
+    assert attrs["adress_ipv6"] == "2001:db8::10"
+    assert attrs["gw_name"] == "WAN"
     assert attrs.get(ATTR_REASON) is None
 
 

--- a/tests/test_sensor_ipv6.py
+++ b/tests/test_sensor_ipv6.py
@@ -294,3 +294,31 @@ def test_wan_status_sensor_reports_ip_sources():
     assert attrs["ip_source"] == "wan_link"
     assert attrs["ipv6"] == "2001:db8::10"
     assert attrs["ipv6_source"] == "wan_health"
+
+
+def test_wan_status_sensor_includes_adress_ipv6_and_gateway_name():
+    link = {
+        "id": "wan1",
+        "name": "WAN",
+    }
+    health = {"id": "wan1"}
+    data = _make_data(
+        wan_links=[link],
+        wan_health=[health],
+        wan={"name": "RAD01-UDM"},
+        wan_attrs={
+            "adress_ipv6": "2001:db8::abcd",
+            "ipv6": "2001:db8::abcd",
+            "gw_name": "RAD01-UDM",
+        },
+        wan_ipv6="2001:db8::abcd",
+    )
+    coordinator = SimpleNamespace(data=data)
+    sensor = UniFiGatewayWanStatusSensor(
+        coordinator, _StubClient(), "entry-id", dict(link)
+    )
+
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["adress_ipv6"] == "2001:db8::abcd"
+    assert attrs["gw_name"] == "RAD01-UDM"


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
