### PR TITLE
Fetch WAN MAC from cloud hosts data

### DIFF
--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -290,7 +290,7 @@ def test_missing_mac_with_ipv4_fetches_ipv6(hass) -> None:
 
     assert coordinator.data is not None
     result = coordinator.data
-    assert result.wan[ATTR_GW_MAC] is None
+    assert result.wan[ATTR_GW_MAC] == "bb:bb:bb:bb:bb:bb"
     assert result.wan_ipv6 == "2001:db8::123"
     attrs = result.wan_attrs
     assert attrs.get(ATTR_REASON) is None


### PR DESCRIPTION
## Summary
- resolve the gateway WAN MAC address by matching the controller WAN IP with UniFi Cloud host entries
- persist the discovered WAN MAC and reuse it when extracting IPv6 data from the cloud response
- update the cloud IPv6 test to expect the WAN MAC to be populated from cloud data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e1157282048327b3f47165d5436da7