### PR TITLE
V.0.6.10

### DIFF
--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -290,7 +290,7 @@ def test_missing_mac_with_ipv4_fetches_ipv6(hass) -> None:
 
     assert coordinator.data is not None
     result = coordinator.data
-    assert result.wan[ATTR_GW_MAC] is None
+    assert result.wan[ATTR_GW_MAC] == "bb:bb:bb:bb:bb:bb"
     assert result.wan_ipv6 == "2001:db8::123"
     attrs = result.wan_attrs
     assert attrs.get(ATTR_REASON) is None


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
