### PR TITLE
Fix WAN IP sensor to prefer IPv4 addresses

### DIFF
--- a/tests/test_sensor_ipv6.py
+++ b/tests/test_sensor_ipv6.py
@@ -196,7 +196,7 @@ def test_wan_ipv6_sensor_handles_unavailable_state():
     assert attrs["gw_mac"] == "78:45:58:d0:95:75"
 
 
-def test_wan_ip_sensor_prefers_ipv6_when_enabled():
+def test_wan_ip_sensor_prefers_ipv4_when_available():
     link = {
         "id": "wan1",
         "name": "WAN",
@@ -214,7 +214,27 @@ def test_wan_ip_sensor_prefers_ipv6_when_enabled():
 
     value = sensor.native_value
 
-    assert value == "2001:db8::5"
+    assert value == "192.0.2.5"
+
+
+def test_wan_ip_sensor_uses_ipv6_when_ipv4_missing():
+    link = {
+        "id": "wan1",
+        "name": "WAN",
+        "last_ipv6": "2001:db8::15",
+    }
+    data = _make_data(
+        wan_links=[link],
+        networks=[{"name": "WAN", "ipv6_interface_type": "dhcpv6"}],
+    )
+    coordinator = SimpleNamespace(data=data)
+    sensor = UniFiGatewayWanIpSensor(
+        coordinator, _StubClient(), "entry-id", dict(link)
+    )
+
+    value = sensor.native_value
+
+    assert value == "2001:db8::15"
 
 
 def test_wan_ip_sensor_uses_ipv4_when_ipv6_disabled():


### PR DESCRIPTION
## Summary
- ensure the WAN IP sensor now prioritizes IPv4 addresses instead of IPv6
- update unit tests to cover the new IPv4-first behaviour while keeping IPv6 fallback coverage

## Testing
- pytest tests/test_sensor_ipv6.py

------
https://chatgpt.com/codex/tasks/task_b_68e122bdb50c83279c667b6f94e933ec