### PR TITLE
V.0.6.11

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/tests/test_sensor_ipv6.py
+++ b/tests/test_sensor_ipv6.py
@@ -196,7 +196,7 @@ def test_wan_ipv6_sensor_handles_unavailable_state():
     assert attrs["gw_mac"] == "78:45:58:d0:95:75"
 
 
-def test_wan_ip_sensor_prefers_ipv6_when_enabled():
+def test_wan_ip_sensor_prefers_ipv4_when_available():
     link = {
         "id": "wan1",
         "name": "WAN",
@@ -214,7 +214,27 @@ def test_wan_ip_sensor_prefers_ipv6_when_enabled():
 
     value = sensor.native_value
 
-    assert value == "2001:db8::5"
+    assert value == "192.0.2.5"
+
+
+def test_wan_ip_sensor_uses_ipv6_when_ipv4_missing():
+    link = {
+        "id": "wan1",
+        "name": "WAN",
+        "last_ipv6": "2001:db8::15",
+    }
+    data = _make_data(
+        wan_links=[link],
+        networks=[{"name": "WAN", "ipv6_interface_type": "dhcpv6"}],
+    )
+    coordinator = SimpleNamespace(data=data)
+    sensor = UniFiGatewayWanIpSensor(
+        coordinator, _StubClient(), "entry-id", dict(link)
+    )
+
+    value = sensor.native_value
+
+    assert value == "2001:db8::15"
 
 
 def test_wan_ip_sensor_uses_ipv4_when_ipv6_disabled():


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
