### PR TITLE
Normalize UniFi controller host input

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -48,6 +48,7 @@ from .cloud_client import (
     UiCloudRateLimitError,
 )
 from .unifi_client import UniFiOSClient, APIError, AuthError, ConnectivityError
+from .utils import normalize_host_port
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,6 +102,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     cleaned[key] = stripped
                     continue
             cleaned[key] = value
+        if CONF_HOST in cleaned:
+            host, derived_port = normalize_host_port(
+                cleaned[CONF_HOST], cleaned.get(CONF_PORT)
+            )
+            if host is None:
+                cleaned.pop(CONF_HOST, None)
+            else:
+                cleaned[CONF_HOST] = host
+                if derived_port is not None:
+                    cleaned[CONF_PORT] = derived_port
         return cleaned
 
     @staticmethod

--- a/custom_components/unifi_gateway_refactored/utils.py
+++ b/custom_components/unifi_gateway_refactored/utils.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+from urllib.parse import urlsplit
+
 
 def build_speedtest_button_unique_id(entry_id: str) -> str:
     """Return a stable unique ID for the Run Speedtest button entity."""
@@ -39,8 +42,57 @@ def normalize_mac(mac: str | None) -> str | None:
     return ":".join(stripped[i:i + 2] for i in range(0, 12, 2))
 
 
+def normalize_host_port(host: Any, port: Any | None = None) -> tuple[str | None, int | None]:
+    """Normalize host text and derive the port when embedded in the address."""
+
+    def _coerce_port(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            return None
+        if number <= 0 or number > 65535:
+            return None
+        return number
+
+    resolved_port = _coerce_port(port)
+
+    if not isinstance(host, str):
+        return None, resolved_port
+
+    text = host.strip()
+    if not text:
+        return None, resolved_port
+
+    candidate = text
+    if "//" not in candidate:
+        # urlsplit requires a scheme or ``//`` prefix to treat the value as a netloc.
+        candidate = f"//{candidate}"
+
+    parsed = urlsplit(candidate, scheme="")
+
+    hostname = parsed.hostname
+    if hostname is None:
+        # ``urlsplit`` returns the raw path when it cannot determine the hostname.
+        path = parsed.path.lstrip("/")
+        hostname = path.split("/")[0] if path else None
+
+    derived_port = parsed.port
+    if derived_port is not None:
+        resolved_port = derived_port
+    elif resolved_port is None:
+        if parsed.scheme == "https":
+            resolved_port = 443
+        elif parsed.scheme == "http":
+            resolved_port = 80
+
+    return (hostname or None), resolved_port
+
+
 __all__ = [
     "build_speedtest_button_unique_id",
     "build_reset_button_unique_id",
     "normalize_mac",
+    "normalize_host_port",
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""Tests for utility helpers."""
+
+import pytest
+
+from custom_components.unifi_gateway_refactored.utils import normalize_host_port
+
+
+@pytest.mark.parametrize(
+    "host,port,expected_host,expected_port",
+    [
+        ("https://controller.local", None, "controller.local", 443),
+        ("https://controller.local:8443", None, "controller.local", 8443),
+        ("controller.local:7443", 443, "controller.local", 7443),
+        ("controller.local/network/site", None, "controller.local", None),
+        ("http://controller.local", 18443, "controller.local", 18443),
+        ("[2001:db8::1]:9443", None, "2001:db8::1", 9443),
+        ("https://[2001:db8::2]", None, "2001:db8::2", 443),
+        (" ", 443, None, 443),
+        (None, None, None, None),
+    ],
+)
+def test_normalize_host_port(host, port, expected_host, expected_port):
+    result_host, result_port = normalize_host_port(host, port)
+    assert result_host == expected_host
+    assert result_port == expected_port


### PR DESCRIPTION
## Summary
- normalize controller host values in the config flow and during setup so URLs with schemes, ports, or paths are handled correctly
- add a shared helper that extracts host/port details (including IPv6) and cover it with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e14797b224832786dc5e1266cb2657