### PR TITLE
V.0.6.13

### DIFF
--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional, cast
 
 import pytest
+import voluptuous as vol
 
 from custom_components.unifi_gateway_refactored.cloud_client import (
     HostItem,
@@ -20,9 +21,19 @@ from custom_components.unifi_gateway_refactored.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_SPEEDTEST_ENTITIES,
+    CONF_SPEEDTEST_INTERVAL,
     CONF_SITE_ID,
     CONF_TIMEOUT,
+    CONF_UI_API_KEY,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    CONF_USE_PROXY_PREFIX,
+    CONF_WIFI_GUEST,
+    CONF_WIFI_IOT,
+    DEFAULT_SITE,
+    DEFAULT_SPEEDTEST_INTERVAL_MINUTES,
+    DEFAULT_TIMEOUT,
 )
 from custom_components.unifi_gateway_refactored.coordinator import (
     UniFiGatewayData,
@@ -409,3 +420,107 @@ def test_options_flow_saves_api_key_and_reload(hass, monkeypatch: pytest.MonkeyP
     asyncio.run(flow.async_step_init({CONF_API_KEY: "abc123"}))
     assert entry.options[CONF_API_KEY] == "abc123"
     assert updated_options[CONF_API_KEY] == "abc123"
+
+
+def test_options_flow_handles_legacy_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = SimpleNamespace(
+        entry_id="4321",
+        data={
+            CONF_HOST: "udm.local",
+            CONF_USERNAME: 123,
+            CONF_PASSWORD: None,
+            CONF_PORT: "8443",
+            CONF_TIMEOUT: "invalid",
+            CONF_SITE_ID: True,
+            CONF_VERIFY_SSL: "yes",
+            CONF_USE_PROXY_PREFIX: None,
+            CONF_SPEEDTEST_ENTITIES: ["sensor.one", " sensor.two "],
+            CONF_UI_API_KEY: "  key  ",
+            CONF_WIFI_GUEST: True,
+            CONF_WIFI_IOT: 12345,
+        },
+        options={
+            CONF_SPEEDTEST_INTERVAL: -30,
+            CONF_WIFI_GUEST: False,
+        },
+    )
+
+    captured: Dict[str, Any] = {}
+
+    def capture_form(*, step_id: str, data_schema: Any, errors: Dict[str, str]) -> Dict[str, Any]:
+        captured["step_id"] = step_id
+        captured["schema"] = data_schema
+        captured["errors"] = errors
+        return {"type": "form"}
+
+    flow = OptionsFlow(cast(config_entries.ConfigEntry, entry))
+    monkeypatch.setattr(flow, "async_show_form", capture_form)
+
+    asyncio.run(flow.async_step_init())
+
+    assert captured["step_id"] == "init"
+    schema = captured["schema"]
+    assert isinstance(schema, vol.Schema)
+    defaults: Dict[str, Any] = {}
+    for key in schema.schema:
+        if isinstance(key, vol.Optional):
+            defaults[key.key] = key.default
+
+    assert defaults[CONF_HOST] == "udm.local"
+    assert defaults[CONF_USERNAME] == "123"
+    assert defaults[CONF_PASSWORD] == ""
+    assert defaults[CONF_SITE_ID] == DEFAULT_SITE
+    assert defaults[CONF_PORT] == 8443
+    assert defaults[CONF_TIMEOUT] == DEFAULT_TIMEOUT
+    assert defaults[CONF_VERIFY_SSL] is True
+    assert defaults[CONF_USE_PROXY_PREFIX] is True
+    assert defaults[CONF_SPEEDTEST_INTERVAL] == DEFAULT_SPEEDTEST_INTERVAL_MINUTES
+    assert defaults[CONF_SPEEDTEST_ENTITIES] == "sensor.one,sensor.two"
+    assert defaults[CONF_UI_API_KEY] == "key"
+    assert defaults[CONF_WIFI_GUEST] == ""
+    assert defaults[CONF_WIFI_IOT] == "12345"
+
+
+def test_options_flow_normalizes_complex_speedtest_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = SimpleNamespace(
+        entry_id="5678",
+        data={
+            CONF_HOST: "udm.local",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_PORT: 443,
+            CONF_TIMEOUT: 10,
+            CONF_SITE_ID: "default",
+        },
+        options={
+            CONF_SPEEDTEST_ENTITIES: {
+                "download": [" sensor.one ", "sensor.two"],
+                "nested": {"upload": "sensor.three\nsensor.four"},
+                "ignored": "",
+            }
+        },
+    )
+
+    captured: Dict[str, Any] = {}
+
+    def capture_form(*, step_id: str, data_schema: Any, errors: Dict[str, str]) -> Dict[str, Any]:
+        captured["schema"] = data_schema
+        return {"type": "form"}
+
+    flow = OptionsFlow(cast(config_entries.ConfigEntry, entry))
+    monkeypatch.setattr(flow, "async_show_form", capture_form)
+
+    asyncio.run(flow.async_step_init())
+
+    schema: vol.Schema = captured["schema"]
+    defaults: Dict[str, Any] = {}
+    for key in schema.schema:
+        if isinstance(key, vol.Optional):
+            defaults[key.key] = key.default
+
+    assert (
+        defaults[CONF_SPEEDTEST_ENTITIES]
+        == "sensor.one,sensor.two,sensor.three,sensor.four"
+    )

--- a/tests/test_unifi_client_connection.py
+++ b/tests/test_unifi_client_connection.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+
+from custom_components.unifi_gateway_refactored.unifi_client import (
+    ConnectivityError,
+    UniFiOSClient,
+)
+
+
+def _install_http_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    class _DummyCookies:
+        def clear(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    class _DummySession:
+        def __init__(self) -> None:
+            self.verify = True
+            self.headers: dict[str, str] = {}
+            self.cookies = _DummyCookies()
+
+        def mount(self, *_args, **_kwargs) -> None:  # pragma: no cover - simple stub
+            return None
+
+        def close(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    class _DummyAdapter:  # pragma: no cover - simple stub
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+    class _DummyRetry:  # pragma: no cover - simple stub
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+    def _disable_warnings(_category) -> None:  # pragma: no cover - simple stub
+        return None
+
+    dummy_requests = types.ModuleType("requests")
+    setattr(dummy_requests, "Session", _DummySession)
+    exceptions_module = types.ModuleType("requests.exceptions")
+    setattr(exceptions_module, "RequestException", Exception)
+    setattr(dummy_requests, "exceptions", exceptions_module)
+
+    dummy_adapters = types.ModuleType("requests.adapters")
+    setattr(dummy_adapters, "HTTPAdapter", _DummyAdapter)
+
+    dummy_packages = types.ModuleType("requests.packages")
+    urllib3_package = types.ModuleType("requests.packages.urllib3")
+    setattr(
+        urllib3_package,
+        "connectionpool",
+        types.ModuleType("requests.packages.urllib3.connectionpool"),
+    )
+    setattr(dummy_packages, "urllib3", urllib3_package)
+
+    setattr(dummy_requests, "adapters", dummy_adapters)
+    setattr(dummy_requests, "packages", dummy_packages)
+
+    dummy_urllib3 = types.ModuleType("urllib3")
+    setattr(dummy_urllib3, "disable_warnings", _disable_warnings)
+    urllib3_exceptions = types.ModuleType("urllib3.exceptions")
+    setattr(urllib3_exceptions, "InsecureRequestWarning", Warning)
+    setattr(dummy_urllib3, "exceptions", urllib3_exceptions)
+
+    dummy_retry = types.ModuleType("urllib3.util.retry")
+    setattr(dummy_retry, "Retry", _DummyRetry)
+
+    monkeypatch.setitem(sys.modules, "requests", dummy_requests)
+    monkeypatch.setitem(sys.modules, "requests.adapters", dummy_adapters)
+    monkeypatch.setitem(sys.modules, "requests.packages", dummy_packages)
+    monkeypatch.setitem(
+        sys.modules,
+        "requests.packages.urllib3",
+        dummy_packages.urllib3,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "requests.packages.urllib3.connectionpool",
+        dummy_packages.urllib3.connectionpool,
+    )
+    monkeypatch.setitem(sys.modules, "urllib3", dummy_urllib3)
+    monkeypatch.setitem(sys.modules, "urllib3.exceptions", dummy_urllib3.exceptions)
+    monkeypatch.setitem(sys.modules, "urllib3.util.retry", dummy_retry)
+
+
+def _stub_login_factory(fail_ports: set[int]):
+    calls: list[tuple[str, int]] = []
+
+    def _login(self: UniFiOSClient, host: str, port: int, ssl_verify: bool, timeout: int) -> None:
+        calls.append(("login", port))
+        if port in fail_ports:
+            raise ConnectivityError(f"fail {port}")
+
+    return calls, _login
+
+
+def _stub_ensure(calls: list[tuple[str, int]]):
+    def _ensure(self: UniFiOSClient) -> None:
+        calls.append(("ensure", self._port))  # type: ignore[attr-defined]
+
+    return _ensure
+
+
+def test_client_falls_back_to_8443(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_http_stubs(monkeypatch)
+    calls, login_stub = _stub_login_factory({443})
+    monkeypatch.setattr(UniFiOSClient, "_login", login_stub)
+    monkeypatch.setattr(UniFiOSClient, "_ensure_connected", _stub_ensure(calls))
+
+    client = UniFiOSClient(
+        host="127.0.0.1",
+        username="user",
+        password="pass",
+        port=443,
+    )
+
+    assert client.port == 8443
+    assert calls == [
+        ("login", 443),
+        ("login", 8443),
+        ("ensure", 8443),
+    ]
+
+
+def test_client_respects_explicit_port_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_http_stubs(monkeypatch)
+    calls, login_stub = _stub_login_factory(set())
+    monkeypatch.setattr(UniFiOSClient, "_login", login_stub)
+    monkeypatch.setattr(UniFiOSClient, "_ensure_connected", _stub_ensure(calls))
+
+    client = UniFiOSClient(
+        host="127.0.0.1",
+        username="user",
+        password="pass",
+        port=8443,
+    )
+
+    assert client.port == 8443
+    assert calls == [
+        ("login", 8443),
+        ("ensure", 8443),
+    ]


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
