### PR TITLE
Fix options flow schema defaults for editing hub

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -458,50 +458,71 @@ class OptionsFlow(config_entries.OptionsFlow):
             )
         if not entities_default:
             entities_default = DEFAULT_SPEEDTEST_ENTITIES
-        schema = vol.Schema(
-            {
-                vol.Optional(CONF_HOST, default=current.get(CONF_HOST)): str,
-                vol.Optional(
-                    CONF_PORT,
-                    default=current.get(CONF_PORT, DEFAULT_PORT),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=65535)),
-                vol.Optional(CONF_USERNAME, default=current.get(CONF_USERNAME)): str,
-                vol.Optional(CONF_PASSWORD, default=current.get(CONF_PASSWORD)): str,
-                vol.Optional(CONF_SITE_ID, default=current.get(CONF_SITE_ID, DEFAULT_SITE)): str,
-                vol.Optional(
-                    CONF_VERIFY_SSL,
-                    default=current.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-                ): bool,
-                vol.Optional(
-                    CONF_USE_PROXY_PREFIX,
-                    default=current.get(
-                        CONF_USE_PROXY_PREFIX, DEFAULT_USE_PROXY_PREFIX
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_TIMEOUT,
-                    default=current.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=1)),
-                vol.Optional(
-                    CONF_SPEEDTEST_INTERVAL,
-                    default=interval_default,
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=5)),
-                vol.Optional(
-                    CONF_SPEEDTEST_ENTITIES,
-                    default=entities_default,
-                ): str,
-                vol.Optional(
-                    CONF_UI_API_KEY,
-                    default=current.get(CONF_UI_API_KEY, ""),
-                ): vol.Any(str, None),
-                vol.Optional(
-                    CONF_WIFI_GUEST,
-                    default=current.get(CONF_WIFI_GUEST),
-                ): vol.Any(str, None),
-                vol.Optional(
-                    CONF_WIFI_IOT,
-                    default=current.get(CONF_WIFI_IOT),
-                ): vol.Any(str, None),
-            }
-        )
+        schema_fields: Dict[Any, Any] = {}
+
+        host_default = current.get(CONF_HOST)
+        if host_default is None:
+            schema_fields[vol.Optional(CONF_HOST)] = str
+        else:
+            schema_fields[vol.Optional(CONF_HOST, default=host_default)] = str
+
+        schema_fields[vol.Optional(
+            CONF_PORT,
+            default=current.get(CONF_PORT, DEFAULT_PORT),
+        )] = vol.All(vol.Coerce(int), vol.Clamp(min=1, max=65535))
+
+        username_default = current.get(CONF_USERNAME)
+        if username_default is None:
+            schema_fields[vol.Optional(CONF_USERNAME)] = str
+        else:
+            schema_fields[vol.Optional(CONF_USERNAME, default=username_default)] = str
+
+        password_default = current.get(CONF_PASSWORD)
+        if password_default is None:
+            schema_fields[vol.Optional(CONF_PASSWORD)] = str
+        else:
+            schema_fields[vol.Optional(CONF_PASSWORD, default=password_default)] = str
+
+        site_default = current.get(CONF_SITE_ID)
+        if site_default is None and CONF_SITE_ID not in current:
+            site_default = DEFAULT_SITE
+        if site_default is None:
+            schema_fields[vol.Optional(CONF_SITE_ID)] = str
+        else:
+            schema_fields[vol.Optional(CONF_SITE_ID, default=site_default)] = str
+
+        schema_fields[vol.Optional(
+            CONF_VERIFY_SSL,
+            default=current.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+        )] = bool
+        schema_fields[vol.Optional(
+            CONF_USE_PROXY_PREFIX,
+            default=current.get(CONF_USE_PROXY_PREFIX, DEFAULT_USE_PROXY_PREFIX),
+        )] = bool
+        schema_fields[vol.Optional(
+            CONF_TIMEOUT,
+            default=current.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+        )] = vol.All(vol.Coerce(int), vol.Clamp(min=1))
+        schema_fields[vol.Optional(
+            CONF_SPEEDTEST_INTERVAL,
+            default=interval_default,
+        )] = vol.All(vol.Coerce(int), vol.Clamp(min=5))
+        schema_fields[vol.Optional(
+            CONF_SPEEDTEST_ENTITIES,
+            default=entities_default,
+        )] = str
+        schema_fields[vol.Optional(
+            CONF_UI_API_KEY,
+            default=current.get(CONF_UI_API_KEY, ""),
+        )] = vol.Any(str, None)
+        schema_fields[vol.Optional(
+            CONF_WIFI_GUEST,
+            default=current.get(CONF_WIFI_GUEST),
+        )] = vol.Any(str, None)
+        schema_fields[vol.Optional(
+            CONF_WIFI_IOT,
+            default=current.get(CONF_WIFI_IOT),
+        )] = vol.Any(str, None)
+
+        schema = vol.Schema(schema_fields)
         return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -384,6 +384,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             attrs["gw_name"] = hostname
         elif data.wan.get("name"):
             attrs.setdefault("gw_name", data.wan.get("name"))
+
         def _normalize_ip(value: Any) -> str | None:
             if isinstance(value, str):
                 cleaned = value.strip()

--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -22,6 +22,7 @@ from custom_components.unifi_gateway_refactored.const import (
     CONF_PORT,
     CONF_SITE_ID,
     CONF_TIMEOUT,
+    CONF_VERIFY_SSL,
     CONF_USERNAME,
 )
 from custom_components.unifi_gateway_refactored.coordinator import (
@@ -409,3 +410,26 @@ def test_options_flow_saves_api_key_and_reload(hass, monkeypatch: pytest.MonkeyP
     asyncio.run(flow.async_step_init({CONF_API_KEY: "abc123"}))
     assert entry.options[CONF_API_KEY] == "abc123"
     assert updated_options[CONF_API_KEY] == "abc123"
+
+
+def test_options_flow_handles_missing_string_defaults(hass) -> None:
+    entry = SimpleNamespace(
+        entry_id="1234",
+        data={
+            CONF_PORT: 443,
+            CONF_TIMEOUT: 10,
+        },
+        options={
+            CONF_VERIFY_SSL: True,
+            CONF_HOST: None,
+            CONF_USERNAME: None,
+            CONF_PASSWORD: None,
+            CONF_SITE_ID: None,
+        },
+    )
+
+    flow = OptionsFlow(cast(config_entries.ConfigEntry, entry))
+    flow.hass = hass  # type: ignore[assignment]
+
+    result = asyncio.run(flow.async_step_init())
+    assert result == {}


### PR DESCRIPTION
## Summary
- ensure the options flow builds its schema without invalid `None` defaults so the hub edit UI no longer fails
- add regression coverage for the options flow handling missing string defaults
- tidy a coordinator helper to satisfy flake8 linting

## Testing
- pytest
- ruff check .
- flake8
- mypy .
- bandit -r custom_components

------
https://chatgpt.com/codex/tasks/task_b_68e15adaeee883278cb69b981219900a