### PR TITLE
Fix hub editing flow and config entry updates

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -405,7 +405,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                         else:
                             current_options[CONF_UI_API_KEY] = normalized_key
                         cleaned.pop(CONF_UI_API_KEY, None)
-                        await self.hass.config_entries.async_update_entry(
+                        self.hass.config_entries.async_update_entry(
                             self._entry,
                             options=current_options,
                         )

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -302,7 +302,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
             self._stored_gw_mac = normalized
             return
         options[CONF_GW_MAC] = normalized
-        await self.hass.config_entries.async_update_entry(
+        self.hass.config_entries.async_update_entry(
             self._config_entry,
             options=options,
         )

--- a/tests/stubs/homeassistant/core.py
+++ b/tests/stubs/homeassistant/core.py
@@ -14,7 +14,7 @@ class _ConfigEntriesManager:
     async def async_unload_platforms(self, entry: Any, platforms: Any) -> bool:
         return True
 
-    async def async_update_entry(
+    def async_update_entry(
         self,
         entry: Any,
         *,

--- a/tests/test_cloud_ipv6.py
+++ b/tests/test_cloud_ipv6.py
@@ -397,7 +397,7 @@ def test_options_flow_saves_api_key_and_reload(hass, monkeypatch: pytest.MonkeyP
     updated_options: Dict[str, Any] = {}
 
     class DummyConfigEntries:
-        async def async_update_entry(self, entry_to_update, *, data=None, options=None):
+        def async_update_entry(self, entry_to_update, *, data=None, options=None):
             if options is not None:
                 entry_to_update.options = dict(options)
                 updated_options.update(options)


### PR DESCRIPTION
## Summary
- remove erroneous awaiting of config entry updates in the options flow and coordinator to fix hub editing errors
- align test stubs with the synchronous Home Assistant API to cover the new behaviour

## Testing
- pytest
- ruff check
- flake8
- mypy custom_components
- bandit -r custom_components

------
https://chatgpt.com/codex/tasks/task_b_68e160df79ac83279e266a030c159ac3