### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -22,6 +22,6 @@
     "custom_components.unifi_gateway_refactored.unifi_client",
     "custom_components.unifi_gateway_refactored.cloud_client"
   ],
-  "logo": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/logo.svg",
-  "icon": "https://github.com/rupert12pl/unifi_gatway_refacoty/blob/main/custom_components/unifi_gateway_refactored/icon.svg"
+  "logo": "custom_components/unifi_gateway_refactored/logo.svg",
+  "icon": "custom_components/unifi_gateway_refactored/icon.svg"
 }


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
