### PR TITLE
Fix optional text defaults in options flow

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -532,15 +532,15 @@ class OptionsFlow(config_entries.OptionsFlow):
         schema_fields[vol.Optional(
             CONF_UI_API_KEY,
             default=current.get(CONF_UI_API_KEY, ""),
-        )] = vol.Any(str, None)
+        )] = str
         schema_fields[vol.Optional(
             CONF_WIFI_GUEST,
-            default=current.get(CONF_WIFI_GUEST),
-        )] = vol.Any(str, None)
+            default=current.get(CONF_WIFI_GUEST, ""),
+        )] = str
         schema_fields[vol.Optional(
             CONF_WIFI_IOT,
-            default=current.get(CONF_WIFI_IOT),
-        )] = vol.Any(str, None)
+            default=current.get(CONF_WIFI_IOT, ""),
+        )] = str
 
         schema = vol.Schema(schema_fields)
         return self.async_show_form(step_id="init", data_schema=schema, errors=errors)


### PR DESCRIPTION
## Summary
- ensure the options flow always provides string defaults for optional text fields
- keep API key and Wi-Fi SSID options editable without triggering form validation errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e17375d2ac8327b2e03fbc054abf0c