### PR TITLE
V.0.6.18

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -189,6 +189,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _normalize_api_key(value: Any) -> Optional[str]:
         if value in (None, ""):
             return None
+        if isinstance(value, bool):
+            return None
         if isinstance(value, str):
             cleaned = value.strip()
             return cleaned or None
@@ -590,17 +592,30 @@ class OptionsFlow(config_entries.OptionsFlow):
             CONF_SPEEDTEST_ENTITIES,
             default=entities_default,
         )] = str
+        api_key_default = ConfigFlow._normalize_api_key(current.get(CONF_UI_API_KEY))
+        if api_key_default is None:
+            api_key_default = ""
         schema_fields[vol.Optional(
             CONF_UI_API_KEY,
-            default=current.get(CONF_UI_API_KEY, ""),
+            default=api_key_default,
         )] = vol.Any(str, None)
+
+        wifi_guest_default = ConfigFlow._normalize_optional_text(
+            current.get(CONF_WIFI_GUEST)
+        )
+        if wifi_guest_default is None:
+            wifi_guest_default = ""
         schema_fields[vol.Optional(
             CONF_WIFI_GUEST,
-            default=current.get(CONF_WIFI_GUEST),
+            default=wifi_guest_default,
         )] = vol.Any(str, None)
+
+        wifi_iot_default = ConfigFlow._normalize_optional_text(current.get(CONF_WIFI_IOT))
+        if wifi_iot_default is None:
+            wifi_iot_default = ""
         schema_fields[vol.Optional(
             CONF_WIFI_IOT,
-            default=current.get(CONF_WIFI_IOT),
+            default=wifi_iot_default,
         )] = vol.Any(str, None)
 
         schema = vol.Schema(schema_fields)

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
