### PR TITLE
V.0.6.20

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -78,7 +78,12 @@ async def _validate_ui_api_key(api_key: Optional[str]) -> None:
     timeout = aiohttp.ClientTimeout(total=10)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         client = UiCloudClient(session, api_key)
-        await client.async_get_hosts()
+        try:
+            await client.async_get_hosts()
+        except UiCloudError:
+            raise
+        except (TypeError, ValueError) as err:
+            raise UiCloudAuthError(400) from err
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -100,6 +105,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         continue
                     cleaned[key] = stripped
                     continue
+            if key == CONF_HOST:
+                normalized_host = ConfigFlow._normalize_host(value)
+                if normalized_host is None:
+                    continue
+                cleaned[key] = normalized_host
+                continue
             cleaned[key] = value
         return cleaned
 
@@ -175,20 +186,82 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _normalize_api_key(value: Any) -> Optional[str]:
         if value in (None, ""):
             return None
+        if isinstance(value, bool):
+            return None
         if isinstance(value, str):
             cleaned = value.strip()
             return cleaned or None
         cleaned = str(value).strip()
         return cleaned or None
 
+    @staticmethod
+    def _normalize_host(value: Any) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        if isinstance(value, str):
+            cleaned = value.strip()
+            return cleaned or None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+    @staticmethod
+    def _coerce_int(
+        value: Any,
+        *,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+    ) -> Optional[int]:
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError):
+            return None
+        if minimum is not None and int_value < minimum:
+            return None
+        if maximum is not None and int_value > maximum:
+            return None
+        return int_value
+
+    @staticmethod
+    def _normalize_speedtest_entities(value: Any) -> str:
+        if isinstance(value, str):
+            collapsed = ",".join(
+                segment.strip()
+                for segment in value.replace("\n", ",").split(",")
+                if segment.strip()
+            )
+            return collapsed or DEFAULT_SPEEDTEST_ENTITIES
+        if isinstance(value, (list, tuple, set)):
+            items: list[str] = []
+            for item in value:
+                if item is None:
+                    continue
+                if isinstance(item, str):
+                    trimmed = item.strip()
+                else:
+                    trimmed = str(item).strip()
+                if trimmed:
+                    items.append(trimmed)
+            collapsed = ",".join(items)
+            if collapsed:
+                return collapsed
+            return DEFAULT_SPEEDTEST_ENTITIES
+        normalized = ConfigFlow._normalize_optional_text(value)
+        if normalized:
+            return normalized
+        return DEFAULT_SPEEDTEST_ENTITIES
+
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         errors: Dict[str, str] = {}
         if user_input is not None:
             sanitized = self._clean_auth_fields(user_input)
-            if self._has_auth(sanitized):
+            host = sanitized.get(CONF_HOST)
+            if host is None:
+                errors["base"] = "missing_host"
+            elif self._has_auth(sanitized):
                 self._cached.update(sanitized)
                 return await self.async_step_advanced()
-            errors["base"] = "missing_auth"
+            else:
+                errors["base"] = "missing_auth"
 
         basic_schema = vol.Schema({
             vol.Required(CONF_HOST): str,
@@ -207,23 +280,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     sanitized[CONF_SPEEDTEST_INTERVAL]
                 )
             if CONF_SPEEDTEST_ENTITIES in sanitized:
-                value = sanitized[CONF_SPEEDTEST_ENTITIES]
-                if isinstance(value, str):
-                    collapsed = ",".join(
-                        segment.strip()
-                        for segment in value.replace("\n", ",").split(",")
-                        if segment.strip()
-                    )
-                    sanitized[CONF_SPEEDTEST_ENTITIES] = (
-                        collapsed or DEFAULT_SPEEDTEST_ENTITIES
-                    )
-                elif isinstance(value, (list, tuple, set)):
-                    collapsed = ",".join(str(item).strip() for item in value if str(item).strip())
-                    sanitized[CONF_SPEEDTEST_ENTITIES] = (
-                        collapsed or DEFAULT_SPEEDTEST_ENTITIES
-                    )
+                sanitized[CONF_SPEEDTEST_ENTITIES] = self._normalize_speedtest_entities(
+                    sanitized[CONF_SPEEDTEST_ENTITIES]
+                )
             self._cached.update(sanitized)
             data = dict(self._cached)
+            normalized_host = self._normalize_host(data.get(CONF_HOST))
+            if normalized_host is None:
+                errors["base"] = "missing_host"
+                self._cached.pop(CONF_HOST, None)
+            else:
+                data[CONF_HOST] = normalized_host
+                self._cached[CONF_HOST] = normalized_host
             for key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
                 if key in data:
                     normalized = self._normalize_optional_text(data[key])
@@ -241,44 +309,45 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     data[CONF_UI_API_KEY] = normalized_key
                     self._cached[CONF_UI_API_KEY] = normalized_key
-            try:
-                # Ensure Home Assistant context is available before validation.
-                assert self.hass is not None  # nosec B101
-                await _validate(self.hass, data)
-                await _validate_ui_api_key(data.get(CONF_UI_API_KEY))
-                await self.async_set_unique_id(
-                    f"{data[CONF_HOST]}:{data.get(CONF_PORT, DEFAULT_PORT)}"
-                )
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=f"UniFi {data[CONF_HOST]}", data=data)
-            except AuthError:
-                errors["base"] = "invalid_auth"
-            except ConnectivityError:
-                errors["base"] = "cannot_connect"
-            except UiCloudAuthError:
-                errors["base"] = "invalid_api_key"
-            except UiCloudRateLimitError:
-                errors["base"] = "api_rate_limited"
-            except UiCloudError:
-                errors["base"] = "api_unavailable"
-            except APIError as err:
-                _LOGGER.error(
-                    "UniFi API error while validating controller %s:%s: %s",
-                    data.get(CONF_HOST),
-                    data.get(CONF_PORT, DEFAULT_PORT),
-                    err,
-                )
-                errors["base"] = "cannot_connect" if not err.expected else "unknown"
-            except AbortFlow:
-                raise
-            except Exception as err:  # pragma: no cover - defensive guard
-                _LOGGER.exception(
-                    "Unexpected error while validating UniFi controller %s:%s: %s",
-                    data.get(CONF_HOST),
-                    data.get(CONF_PORT, DEFAULT_PORT),
-                    err,
-                )
-                errors["base"] = "unknown"
+            if not errors:
+                try:
+                    # Ensure Home Assistant context is available before validation.
+                    assert self.hass is not None  # nosec B101
+                    await _validate(self.hass, data)
+                    await _validate_ui_api_key(data.get(CONF_UI_API_KEY))
+                    await self.async_set_unique_id(
+                        f"{data[CONF_HOST]}:{data.get(CONF_PORT, DEFAULT_PORT)}"
+                    )
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(title=f"UniFi {data[CONF_HOST]}", data=data)
+                except AuthError:
+                    errors["base"] = "invalid_auth"
+                except ConnectivityError:
+                    errors["base"] = "cannot_connect"
+                except UiCloudAuthError:
+                    errors["base"] = "invalid_api_key"
+                except UiCloudRateLimitError:
+                    errors["base"] = "api_rate_limited"
+                except UiCloudError:
+                    errors["base"] = "api_unavailable"
+                except APIError as err:
+                    _LOGGER.error(
+                        "UniFi API error while validating controller %s:%s: %s",
+                        data.get(CONF_HOST),
+                        data.get(CONF_PORT, DEFAULT_PORT),
+                        err,
+                    )
+                    errors["base"] = "cannot_connect" if not err.expected else "unknown"
+                except AbortFlow:
+                    raise
+                except Exception as err:  # pragma: no cover - defensive guard
+                    _LOGGER.exception(
+                        "Unexpected error while validating UniFi controller %s:%s: %s",
+                        data.get(CONF_HOST),
+                        data.get(CONF_PORT, DEFAULT_PORT),
+                        err,
+                    )
+                    errors["base"] = "unknown"
 
         interval_default = self._seconds_to_minutes(
             self._resolve_interval_seconds(self._cached)
@@ -286,21 +355,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if interval_default <= 0:
             interval_default = DEFAULT_SPEEDTEST_INTERVAL_MINUTES
 
-        entities_default = self._cached.get(
-            CONF_SPEEDTEST_ENTITIES, DEFAULT_SPEEDTEST_ENTITIES
+        entities_default = self._normalize_speedtest_entities(
+            self._cached.get(CONF_SPEEDTEST_ENTITIES)
         )
-        if isinstance(entities_default, (list, tuple, set)):
-            entities_default = ",".join(
-                str(item).strip() for item in entities_default if str(item).strip()
-            )
-        if not entities_default:
-            entities_default = DEFAULT_SPEEDTEST_ENTITIES
 
         adv_schema = vol.Schema(
             {
                 vol.Optional(
                     CONF_PORT,
-                    default=self._cached.get(CONF_PORT, DEFAULT_PORT),
+                    default=self._coerce_int(
+                        self._cached.get(CONF_PORT),
+                        minimum=1,
+                        maximum=65535,
+                    )
+                    or DEFAULT_PORT,
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=1, max=65535)),
                 vol.Optional(
                     CONF_SITE_ID,
@@ -314,7 +382,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ): bool,
                 vol.Optional(
                     CONF_TIMEOUT,
-                    default=self._cached.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                    default=self._coerce_int(
+                        self._cached.get(CONF_TIMEOUT), minimum=1
+                    )
+                    or DEFAULT_TIMEOUT,
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=1)),
                 vol.Optional(
                     CONF_SPEEDTEST_INTERVAL,
@@ -329,15 +400,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ): str,
                 vol.Optional(
                     CONF_UI_API_KEY,
-                    default=self._cached.get(CONF_UI_API_KEY, ""),
+                    default=self._normalize_api_key(
+                        self._cached.get(CONF_UI_API_KEY)
+                    )
+                    or "",
                 ): str,
                 vol.Optional(
                     CONF_WIFI_GUEST,
-                    default=self._cached.get(CONF_WIFI_GUEST, ""),
+                    default=self._normalize_optional_text(
+                        self._cached.get(CONF_WIFI_GUEST)
+                    )
+                    or "",
                 ): str,
                 vol.Optional(
                     CONF_WIFI_IOT,
-                    default=self._cached.get(CONF_WIFI_IOT, ""),
+                    default=self._normalize_optional_text(
+                        self._cached.get(CONF_WIFI_IOT)
+                    )
+                    or "",
                 ): str,
             }
         )
@@ -359,44 +439,128 @@ class OptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         errors: Dict[str, str] = {}
+        wifi_cleared: set[str] = set()
         if user_input is not None:
             cleaned = ConfigFlow._clean_auth_fields(user_input)
+            host_provided = CONF_HOST in user_input
+            provided_host = (
+                ConfigFlow._normalize_host(user_input.get(CONF_HOST))
+                if host_provided
+                else None
+            )
+            wifi_cleared = set()
+            for wifi_key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
+                if wifi_key in user_input:
+                    normalized_wifi = ConfigFlow._normalize_optional_text(
+                        user_input.get(wifi_key)
+                    )
+                    if normalized_wifi is None:
+                        wifi_cleared.add(wifi_key)
+                        cleaned.pop(wifi_key, None)
+                    else:
+                        cleaned[wifi_key] = normalized_wifi
             if CONF_SPEEDTEST_INTERVAL in cleaned:
                 cleaned[CONF_SPEEDTEST_INTERVAL] = ConfigFlow._minutes_to_seconds(
                     cleaned[CONF_SPEEDTEST_INTERVAL]
                 )
             if CONF_SPEEDTEST_ENTITIES in cleaned:
-                value = cleaned[CONF_SPEEDTEST_ENTITIES]
-                if isinstance(value, str):
-                    collapsed = ",".join(
-                        segment.strip()
-                        for segment in value.replace("\n", ",").split(",")
-                        if segment.strip()
-                    )
-                    cleaned[CONF_SPEEDTEST_ENTITIES] = (
-                        collapsed or DEFAULT_SPEEDTEST_ENTITIES
-                    )
-                elif isinstance(value, (list, tuple, set)):
-                    collapsed = ",".join(str(item).strip() for item in value if str(item).strip())
-                    cleaned[CONF_SPEEDTEST_ENTITIES] = (
-                        collapsed or DEFAULT_SPEEDTEST_ENTITIES
-                    )
+                cleaned[CONF_SPEEDTEST_ENTITIES] = ConfigFlow._normalize_speedtest_entities(
+                    cleaned[CONF_SPEEDTEST_ENTITIES]
+                )
             for key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
                 if key in cleaned:
-                    cleaned[key] = ConfigFlow._normalize_optional_text(cleaned[key])
+                    normalized_wifi = ConfigFlow._normalize_optional_text(cleaned[key])
+                    if normalized_wifi is None:
+                        cleaned.pop(key, None)
+                    else:
+                        cleaned[key] = normalized_wifi
             if CONF_UI_API_KEY in cleaned:
-                cleaned[CONF_UI_API_KEY] = ConfigFlow._normalize_api_key(
-                    cleaned[CONF_UI_API_KEY]
-                )
+                normalized_key = ConfigFlow._normalize_api_key(cleaned[CONF_UI_API_KEY])
+                if normalized_key is None:
+                    cleaned.pop(CONF_UI_API_KEY, None)
+                else:
+                    cleaned[CONF_UI_API_KEY] = normalized_key
             merged = {**self._entry.data, **self._entry.options, **cleaned}
-            if not ConfigFlow._has_auth(merged):
+            normalized_host = ConfigFlow._normalize_host(merged.get(CONF_HOST))
+            if host_provided and provided_host is None:
+                errors["base"] = "missing_host"
+            elif normalized_host is None:
+                errors["base"] = "missing_host"
+            elif not ConfigFlow._has_auth(merged):
                 errors["base"] = "missing_auth"
             else:
                 try:
                     # Ensure Home Assistant context is available before validation.
                     assert self.hass is not None  # nosec B101
+                    merged[CONF_HOST] = normalized_host
+                    cleaned[CONF_HOST] = normalized_host
+                    normalized_key = ConfigFlow._normalize_api_key(
+                        merged.get(CONF_UI_API_KEY)
+                    )
+                    if normalized_key is None:
+                        merged.pop(CONF_UI_API_KEY, None)
+                    else:
+                        merged[CONF_UI_API_KEY] = normalized_key
+                        cleaned.setdefault(CONF_UI_API_KEY, normalized_key)
+                    if CONF_SPEEDTEST_ENTITIES in merged:
+                        merged[CONF_SPEEDTEST_ENTITIES] = (
+                            ConfigFlow._normalize_speedtest_entities(
+                                merged[CONF_SPEEDTEST_ENTITIES]
+                            )
+                        )
+                        if CONF_SPEEDTEST_ENTITIES in cleaned:
+                            cleaned[CONF_SPEEDTEST_ENTITIES] = merged[
+                                CONF_SPEEDTEST_ENTITIES
+                            ]
+                    for wifi_key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
+                        if wifi_key in wifi_cleared:
+                            merged.pop(wifi_key, None)
+                            cleaned.pop(wifi_key, None)
+                            continue
+                        normalized_wifi = ConfigFlow._normalize_optional_text(
+                            merged.get(wifi_key)
+                        )
+                        if normalized_wifi is None:
+                            merged.pop(wifi_key, None)
+                            cleaned.pop(wifi_key, None)
+                        else:
+                            merged[wifi_key] = normalized_wifi
+                            if wifi_key in cleaned:
+                                cleaned[wifi_key] = normalized_wifi
                     await _validate(self.hass, merged)
                     await _validate_ui_api_key(merged.get(CONF_UI_API_KEY))
+                    if self.hass is not None:
+                        current_data = dict(self._entry.data)
+                        updated = False
+                        relevant_keys = {
+                            CONF_HOST,
+                            CONF_USERNAME,
+                            CONF_PASSWORD,
+                            CONF_PORT,
+                            CONF_SITE_ID,
+                            CONF_VERIFY_SSL,
+                            CONF_USE_PROXY_PREFIX,
+                            CONF_TIMEOUT,
+                            CONF_SPEEDTEST_INTERVAL,
+                            CONF_SPEEDTEST_ENTITIES,
+                            CONF_UI_API_KEY,
+                            CONF_WIFI_GUEST,
+                            CONF_WIFI_IOT,
+                        }
+                        for key in relevant_keys:
+                            if key in merged:
+                                value = merged[key]
+                                if current_data.get(key) != value:
+                                    current_data[key] = value
+                                    updated = True
+                            elif key in current_data:
+                                current_data.pop(key)
+                                updated = True
+                        if updated:
+                            self.hass.config_entries.async_update_entry(
+                                self._entry,
+                                data=current_data,
+                            )
                     if CONF_UI_API_KEY in cleaned:
                         current_options = dict(self._entry.options)
                         normalized_key = cleaned[CONF_UI_API_KEY]
@@ -404,8 +568,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                             current_options.pop(CONF_UI_API_KEY, None)
                         else:
                             current_options[CONF_UI_API_KEY] = normalized_key
-                        cleaned.pop(CONF_UI_API_KEY, None)
-                        await self.hass.config_entries.async_update_entry(
+                        self.hass.config_entries.async_update_entry(
                             self._entry,
                             options=current_options,
                         )
@@ -444,20 +607,19 @@ class OptionsFlow(config_entries.OptionsFlow):
                     errors["base"] = "unknown"
 
         current = {**self._entry.data, **self._entry.options}
+        host_default = ConfigFlow._normalize_host(current.get(CONF_HOST))
+        if host_default is not None:
+            current[CONF_HOST] = host_default
+        else:
+            current.pop(CONF_HOST, None)
         interval_default = ConfigFlow._seconds_to_minutes(
             ConfigFlow._resolve_interval_seconds(current)
         )
         if interval_default <= 0:
             interval_default = DEFAULT_SPEEDTEST_INTERVAL_MINUTES
-        entities_default = current.get(
-            CONF_SPEEDTEST_ENTITIES, DEFAULT_SPEEDTEST_ENTITIES
+        entities_default = ConfigFlow._normalize_speedtest_entities(
+            current.get(CONF_SPEEDTEST_ENTITIES)
         )
-        if isinstance(entities_default, (list, tuple, set)):
-            entities_default = ",".join(
-                str(item).strip() for item in entities_default if str(item).strip()
-            )
-        if not entities_default:
-            entities_default = DEFAULT_SPEEDTEST_ENTITIES
         schema_fields: Dict[Any, Any] = {}
 
         host_default = current.get(CONF_HOST)
@@ -468,22 +630,29 @@ class OptionsFlow(config_entries.OptionsFlow):
 
         schema_fields[vol.Optional(
             CONF_PORT,
-            default=current.get(CONF_PORT, DEFAULT_PORT),
+            default=ConfigFlow._coerce_int(
+                current.get(CONF_PORT), minimum=1, maximum=65535
+            )
+            or DEFAULT_PORT,
         )] = vol.All(vol.Coerce(int), vol.Clamp(min=1, max=65535))
 
-        username_default = current.get(CONF_USERNAME)
+        username_default = ConfigFlow._normalize_optional_text(
+            current.get(CONF_USERNAME)
+        )
         if username_default is None:
             schema_fields[vol.Optional(CONF_USERNAME)] = str
         else:
             schema_fields[vol.Optional(CONF_USERNAME, default=username_default)] = str
 
-        password_default = current.get(CONF_PASSWORD)
+        password_default = ConfigFlow._normalize_optional_text(
+            current.get(CONF_PASSWORD)
+        )
         if password_default is None:
             schema_fields[vol.Optional(CONF_PASSWORD)] = str
         else:
             schema_fields[vol.Optional(CONF_PASSWORD, default=password_default)] = str
 
-        site_default = current.get(CONF_SITE_ID)
+        site_default = ConfigFlow._normalize_optional_text(current.get(CONF_SITE_ID))
         if site_default is None and CONF_SITE_ID not in current:
             site_default = DEFAULT_SITE
         if site_default is None:
@@ -501,7 +670,10 @@ class OptionsFlow(config_entries.OptionsFlow):
         )] = bool
         schema_fields[vol.Optional(
             CONF_TIMEOUT,
-            default=current.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            default=ConfigFlow._coerce_int(
+                current.get(CONF_TIMEOUT), minimum=1
+            )
+            or DEFAULT_TIMEOUT,
         )] = vol.All(vol.Coerce(int), vol.Clamp(min=1))
         schema_fields[vol.Optional(
             CONF_SPEEDTEST_INTERVAL,
@@ -511,17 +683,26 @@ class OptionsFlow(config_entries.OptionsFlow):
             CONF_SPEEDTEST_ENTITIES,
             default=entities_default,
         )] = str
+        ui_key_default = (
+            ConfigFlow._normalize_api_key(current.get(CONF_UI_API_KEY)) or ""
+        )
         schema_fields[vol.Optional(
             CONF_UI_API_KEY,
-            default=current.get(CONF_UI_API_KEY, ""),
+            default=ui_key_default,
         )] = vol.Any(str, None)
+        wifi_guest_default = (
+            ConfigFlow._normalize_optional_text(current.get(CONF_WIFI_GUEST)) or ""
+        )
         schema_fields[vol.Optional(
             CONF_WIFI_GUEST,
-            default=current.get(CONF_WIFI_GUEST),
+            default=wifi_guest_default,
         )] = vol.Any(str, None)
+        wifi_iot_default = (
+            ConfigFlow._normalize_optional_text(current.get(CONF_WIFI_IOT)) or ""
+        )
         schema_fields[vol.Optional(
             CONF_WIFI_IOT,
-            default=current.get(CONF_WIFI_IOT),
+            default=wifi_iot_default,
         )] = vol.Any(str, None)
 
         schema = vol.Schema(schema_fields)


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
