### PR TITLE
V.0.6.21

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,5 @@
+# Bandit configuration to skip unit tests that intentionally use asserts.
+exclude_dirs:
+  - tests
+skips:
+  - B101

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/custom_components/unifi_gateway_refactored/unifi_client.py
+++ b/custom_components/unifi_gateway_refactored/unifi_client.py
@@ -95,7 +95,7 @@ class UniFiOSClient:
         password: str | None = None,
         port: int = 443,
         site_id: str = DEFAULT_SITE,
-        ssl_verify: bool = False,
+        ssl_verify: bool | str = False,
         use_proxy_prefix: bool = True,
         timeout: int = 10,
         instance_hint: str | None = None,
@@ -581,7 +581,7 @@ class UniFiOSClient:
     def _get(self, path: str, *, timeout: Optional[int] = None) -> Any:
         return self._request_json("GET", path, timeout=timeout)
 
-    def _login(self, host: str, port: int, ssl_verify: bool, timeout: int) -> None:
+    def _login(self, host: str, port: int, ssl_verify: bool | str, timeout: int) -> None:
         requests = self._requests_module()
 
         base = f"{self._scheme}://{host}:{port}"

--- a/tests/stubs/homeassistant/helpers/config_validation.py
+++ b/tests/stubs/homeassistant/helpers/config_validation.py
@@ -1,0 +1,47 @@
+"""Minimal stub implementations for Home Assistant config validation helpers."""
+
+from __future__ import annotations
+
+from typing import Type, cast
+
+import voluptuous as vol
+
+try:
+    Invalid = cast(Type[Exception], vol.Invalid)  # type: ignore[attr-defined]
+except AttributeError:  # pragma: no cover - stub fallback
+    class _VoluptuousInvalid(Exception):
+        pass
+
+    Invalid = _VoluptuousInvalid
+
+
+def boolean(value):
+    """Coerce a value to boolean using Home Assistant style semantics."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        if value == 0:
+            return False
+        if value == 1:
+            return True
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "on", "yes", "y", "1"}:
+            return True
+        if normalized in {"false", "off", "no", "n", "0"}:
+            return False
+    raise Invalid(f"Invalid boolean value: {value!r}")
+
+
+def string(value):
+    """Ensure the provided value is a string."""
+
+    if isinstance(value, str):
+        return value
+    if value is None:
+        raise Invalid("String value cannot be None")
+    return str(value)
+
+
+__all__ = ["boolean", "string"]

--- a/tests/stubs/voluptuous.py
+++ b/tests/stubs/voluptuous.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import Any as TypingAny, Callable
 
 
+class Invalid(Exception):
+    """Minimal Invalid exception stub."""
+
+
 class Schema:
     def __init__(self, schema: TypingAny) -> None:
         self.schema = schema

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from custom_components.unifi_gateway_refactored.const import (
     CONF_PASSWORD,
     CONF_TIMEOUT,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
     CONF_WIFI_GUEST,
     CONF_WIFI_IOT,
     CONF_UI_API_KEY,
@@ -138,6 +139,53 @@ def test_options_flow_rejects_blank_host(
     assert captured.get("errors", {}).get("base") == "missing_host"
 
 
+def test_options_flow_populates_verify_ssl_path_default(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    entry = cast(
+        ConfigEntry,
+        SimpleNamespace(
+            entry_id="verify-path",
+            data={
+                CONF_HOST: "udm.local",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_VERIFY_SSL: "/config/custom-ca.pem",
+            },
+            options={},
+        ),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_options_form(
+        self, *, step_id, data_schema=None, errors=None, description_placeholders=None
+    ):
+        captured["step_id"] = step_id
+        captured["schema"] = data_schema
+        captured["errors"] = errors or {}
+        return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+    monkeypatch.setattr(OptionsFlow, "async_show_form", fake_options_form, raising=False)
+
+    flow = OptionsFlow(entry)
+    flow.hass = hass  # type: ignore[assignment]
+
+    result = run(flow.async_step_init())
+
+    assert result["step_id"] == "init"
+    assert captured.get("errors") == {}
+
+    schema = captured.get("schema")
+    assert schema is not None
+    verify_defaults = []
+    for field in getattr(schema, "schema", {}):  # type: ignore[union-attr]
+        key = getattr(field, "key", getattr(field, "schema", None))
+        if key == CONF_VERIFY_SSL:
+            verify_defaults.append(getattr(field, "default", None))
+    assert verify_defaults == ["/config/custom-ca.pem"]
+
+
 def test_advanced_step_normalizes_cached_host(
     hass, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -206,6 +254,70 @@ def test_advanced_step_normalizes_cached_host(
     assert created_entry["unique_id"] == "udm.local:8443"
     assert flow._cached[CONF_HOST] == "udm.local"
     assert validate_payload[CONF_HOST] == "udm.local"
+
+
+def test_advanced_step_accepts_verify_ssl_path(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_validate(_hass: Any, data: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def fake_validate_key(_api_key: str | None) -> None:
+        return None
+
+    async def fake_set_unique_id(
+        self, unique_id: str, *, raise_on_progress: bool = False
+    ) -> None:  # type: ignore[override]
+        return None
+
+    def fake_abort_if_unique_id_configured(self) -> None:  # type: ignore[override]
+        return None
+
+    def fake_create_entry(
+        self, *, title: str, data: dict[str, Any]
+    ) -> dict[str, Any]:  # type: ignore[override]
+        return {"type": "create_entry", "title": title, "data": data}
+
+    monkeypatch.setattr(
+        "custom_components.unifi_gateway_refactored.config_flow._validate",
+        fake_validate,
+    )
+    monkeypatch.setattr(
+        "custom_components.unifi_gateway_refactored.config_flow._validate_ui_api_key",
+        fake_validate_key,
+    )
+    monkeypatch.setattr(
+        ConfigFlow, "async_set_unique_id", fake_set_unique_id, raising=False
+    )
+    monkeypatch.setattr(
+        ConfigFlow,
+        "_abort_if_unique_id_configured",
+        fake_abort_if_unique_id_configured,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ConfigFlow, "async_create_entry", fake_create_entry, raising=False
+    )
+
+    flow = ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow._cached = {
+        CONF_HOST: "udm.local",
+        CONF_USERNAME: "user",
+        CONF_PASSWORD: "pass",
+    }
+
+    result = run(
+        flow.async_step_advanced(
+            {
+                CONF_VERIFY_SSL: "  /config/custom-ca.pem  ",
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_VERIFY_SSL] == "/config/custom-ca.pem"
+    assert flow._cached[CONF_VERIFY_SSL] == "/config/custom-ca.pem"
 
 
 def test_advanced_step_handles_invalid_api_key_characters(


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
