### PR TITLE
V.0.6.23

### DIFF
--- a/custom_components/unifi_gateway_refactored/const.py
+++ b/custom_components/unifi_gateway_refactored/const.py
@@ -22,6 +22,7 @@ CONF_API_KEY = "api_key"
 # Backwards compatibility alias for legacy option name
 CONF_UI_API_KEY = CONF_API_KEY
 CONF_GW_MAC = "gw_mac"
+CONF_VERIFY_SSL_CA = "verify_ssl_ca"
 
 DEFAULT_PORT = 443
 DEFAULT_SITE = "default"

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.21",
+  "version": "0.6.23",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
