### PR TITLE
V.0.6.25

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -35,7 +35,6 @@ from .const import (
     CONF_HOST,
     CONF_PORT,
     CONF_VERIFY_SSL,
-    CONF_VERIFY_SSL_CA,
     CONF_USE_PROXY_PREFIX,
     CONF_SITE_ID,
     CONF_TIMEOUT,
@@ -133,18 +132,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 cleaned[key] = normalized_host
                 continue
             cleaned[key] = value
-
-        ca_raw = cleaned.get(CONF_VERIFY_SSL_CA)
-        ca_value = ""
-        if isinstance(ca_raw, str):
-            ca_value = ca_raw.strip()
-        elif ca_raw is not None:
-            ca_value = str(ca_raw).strip()
-
-        if ca_value:
-            cleaned[CONF_VERIFY_SSL] = ca_value
-
-        cleaned.pop(CONF_VERIFY_SSL_CA, None)
         return cleaned
 
     @staticmethod
@@ -521,11 +508,7 @@ class OptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         errors: Dict[str, str] = {}
-        cleaned: Dict[str, Any] = {}
         wifi_cleared: set[str] = set()
-        host_provided = False
-        provided_host: Optional[str] = None
-
         if user_input is not None:
             cleaned = ConfigFlow._clean_auth_fields(user_input)
             host_provided = CONF_HOST in user_input
@@ -534,7 +517,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                 if host_provided
                 else None
             )
-
             wifi_cleared = set()
             for wifi_key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
                 if wifi_key in user_input:
@@ -546,7 +528,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                         cleaned.pop(wifi_key, None)
                     else:
                         cleaned[wifi_key] = normalized_wifi
-
             if CONF_VERIFY_SSL in cleaned:
                 normalized_verify = ConfigFlow._normalize_verify_ssl(
                     cleaned[CONF_VERIFY_SSL]
@@ -555,17 +536,14 @@ class OptionsFlow(config_entries.OptionsFlow):
                     cleaned.pop(CONF_VERIFY_SSL, None)
                 else:
                     cleaned[CONF_VERIFY_SSL] = normalized_verify
-
             if CONF_SPEEDTEST_INTERVAL in cleaned:
                 cleaned[CONF_SPEEDTEST_INTERVAL] = ConfigFlow._minutes_to_seconds(
                     cleaned[CONF_SPEEDTEST_INTERVAL]
                 )
-
             if CONF_SPEEDTEST_ENTITIES in cleaned:
                 cleaned[CONF_SPEEDTEST_ENTITIES] = ConfigFlow._normalize_speedtest_entities(
                     cleaned[CONF_SPEEDTEST_ENTITIES]
                 )
-
             for key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
                 if key in cleaned:
                     normalized_wifi = ConfigFlow._normalize_optional_text(cleaned[key])
@@ -573,14 +551,12 @@ class OptionsFlow(config_entries.OptionsFlow):
                         cleaned.pop(key, None)
                     else:
                         cleaned[key] = normalized_wifi
-
             if CONF_UI_API_KEY in cleaned:
                 normalized_key = ConfigFlow._normalize_api_key(cleaned[CONF_UI_API_KEY])
-                if not normalized_key:
+                if normalized_key is None:
                     cleaned.pop(CONF_UI_API_KEY, None)
                 else:
                     cleaned[CONF_UI_API_KEY] = normalized_key
-
             merged = {**self._entry.data, **self._entry.options, **cleaned}
             normalized_host = ConfigFlow._normalize_host(merged.get(CONF_HOST))
             if host_provided and provided_host is None:
@@ -591,10 +567,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "missing_auth"
             else:
                 try:
+                    # Ensure Home Assistant context is available before validation.
                     assert self.hass is not None  # nosec B101
                     merged[CONF_HOST] = normalized_host
                     cleaned[CONF_HOST] = normalized_host
-
                     normalized_key = ConfigFlow._normalize_api_key(
                         merged.get(CONF_UI_API_KEY)
                     )
@@ -603,7 +579,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                     else:
                         merged[CONF_UI_API_KEY] = normalized_key
                         cleaned.setdefault(CONF_UI_API_KEY, normalized_key)
-
                     normalized_verify = ConfigFlow._normalize_verify_ssl(
                         merged.get(CONF_VERIFY_SSL)
                     )
@@ -614,7 +589,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                         merged[CONF_VERIFY_SSL] = normalized_verify
                         if CONF_VERIFY_SSL in cleaned:
                             cleaned[CONF_VERIFY_SSL] = normalized_verify
-
                     if CONF_SPEEDTEST_ENTITIES in merged:
                         merged[CONF_SPEEDTEST_ENTITIES] = (
                             ConfigFlow._normalize_speedtest_entities(
@@ -625,7 +599,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                             cleaned[CONF_SPEEDTEST_ENTITIES] = merged[
                                 CONF_SPEEDTEST_ENTITIES
                             ]
-
                     for wifi_key in (CONF_WIFI_GUEST, CONF_WIFI_IOT):
                         if wifi_key in wifi_cleared:
                             merged.pop(wifi_key, None)
@@ -641,10 +614,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                             merged[wifi_key] = normalized_wifi
                             if wifi_key in cleaned:
                                 cleaned[wifi_key] = normalized_wifi
-
                     await _validate(self.hass, merged)
                     await _validate_ui_api_key(merged.get(CONF_UI_API_KEY))
-
                     if self.hass is not None:
                         current_data = dict(self._entry.data)
                         updated = False
@@ -677,7 +648,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                                 self._entry,
                                 data=current_data,
                             )
-
                     if CONF_UI_API_KEY in cleaned:
                         current_options = dict(self._entry.options)
                         normalized_key = cleaned[CONF_UI_API_KEY]
@@ -689,7 +659,6 @@ class OptionsFlow(config_entries.OptionsFlow):
                             self._entry,
                             options=current_options,
                         )
-
                     return self.async_create_entry(title="", data=cleaned)
                 except AuthError:
                     errors["base"] = "invalid_auth"
@@ -796,8 +765,6 @@ class OptionsFlow(config_entries.OptionsFlow):
             CONF_VERIFY_SSL,
             default=verify_default,
         )] = vol.Any(cv.boolean, vol.All(_ensure_non_empty_string))
-        schema_fields[vol.Optional(CONF_VERIFY_SSL_CA, default=verify_default if isinstance(verify_default, str) else "")] = str
-
         schema_fields[vol.Optional(
             CONF_SPEEDTEST_INTERVAL,
             default=interval_default,
@@ -809,8 +776,10 @@ class OptionsFlow(config_entries.OptionsFlow):
         ui_key_default = (
             ConfigFlow._normalize_api_key(current.get(CONF_UI_API_KEY)) or ""
         )
-        schema_fields[vol.Optional(CONF_UI_API_KEY, default=ui_key_default)] = str
-
+        schema_fields[vol.Optional(
+            CONF_UI_API_KEY,
+            default=ui_key_default,
+        )] = vol.Any(str, None)
         wifi_guest_default = (
             ConfigFlow._normalize_optional_text(current.get(CONF_WIFI_GUEST)) or ""
         )

--- a/custom_components/unifi_gateway_refactored/const.py
+++ b/custom_components/unifi_gateway_refactored/const.py
@@ -22,7 +22,6 @@ CONF_API_KEY = "api_key"
 # Backwards compatibility alias for legacy option name
 CONF_UI_API_KEY = CONF_API_KEY
 CONF_GW_MAC = "gw_mac"
-CONF_VERIFY_SSL_CA = "verify_ssl_ca"
 
 DEFAULT_PORT = 443
 DEFAULT_SITE = "default"

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.21",
+  "version": "0.6.25",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.23",
+  "version": "0.6.21",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
