### PR TITLE
V.0.6.27

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, Optional, TYPE_CHECKING
+from collections.abc import Mapping
 
 import aiohttp
 
@@ -50,6 +51,28 @@ from .cloud_client import (
 from .unifi_client import UniFiOSClient, APIError, AuthError, ConnectivityError
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    """Return a mutable dictionary for mapping-like config entry data."""
+
+    if value is None:
+        return {}
+
+    if isinstance(value, dict):
+        return dict(value)
+
+    if isinstance(value, Mapping):
+        return dict(value)
+
+    try:
+        return dict(value)  # type: ignore[arg-type]
+    except Exception:  # pragma: no cover - defensive guard
+        _LOGGER.warning(
+            "Unexpected non-mapping config entry payload of type %s; treating as empty",
+            type(value),
+        )
+        return {}
 
 
 async def _validate(hass: HomeAssistant, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -440,6 +463,9 @@ class OptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         errors: Dict[str, str] = {}
         wifi_cleared: set[str] = set()
+        entry_data = _as_dict(self._entry.data)
+        entry_options = _as_dict(self._entry.options)
+
         if user_input is not None:
             cleaned = ConfigFlow._clean_auth_fields(user_input)
             host_provided = CONF_HOST in user_input
@@ -480,7 +506,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     cleaned.pop(CONF_UI_API_KEY, None)
                 else:
                     cleaned[CONF_UI_API_KEY] = normalized_key
-            merged = {**self._entry.data, **self._entry.options, **cleaned}
+            merged = {**entry_data, **entry_options, **cleaned}
             normalized_host = ConfigFlow._normalize_host(merged.get(CONF_HOST))
             if host_provided and provided_host is None:
                 errors["base"] = "missing_host"
@@ -530,7 +556,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     await _validate(self.hass, merged)
                     await _validate_ui_api_key(merged.get(CONF_UI_API_KEY))
                     if self.hass is not None:
-                        current_data = dict(self._entry.data)
+                        current_data = _as_dict(self._entry.data)
                         updated = False
                         relevant_keys = {
                             CONF_HOST,
@@ -562,7 +588,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                                 data=current_data,
                             )
                     if CONF_UI_API_KEY in cleaned:
-                        current_options = dict(self._entry.options)
+                        current_options = _as_dict(self._entry.options)
                         normalized_key = cleaned[CONF_UI_API_KEY]
                         if normalized_key is None:
                             current_options.pop(CONF_UI_API_KEY, None)
@@ -606,7 +632,9 @@ class OptionsFlow(config_entries.OptionsFlow):
                     )
                     errors["base"] = "unknown"
 
-        current = {**self._entry.data, **self._entry.options}
+        entry_data = _as_dict(self._entry.data)
+        entry_options = _as_dict(self._entry.options)
+        current = {**entry_data, **entry_options}
         host_default = ConfigFlow._normalize_host(current.get(CONF_HOST))
         if host_default is not None:
             current[CONF_HOST] = host_default

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
