### PR TITLE
Handle missing config entry options in UniFi coordinator

### DIFF
--- a/custom_components/unifi_gateway_refactored/config_flow.py
+++ b/custom_components/unifi_gateway_refactored/config_flow.py
@@ -437,6 +437,14 @@ class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, entry: config_entries.ConfigEntry) -> None:
         self._entry = entry
 
+    def _entry_options(self) -> Dict[str, Any]:
+        """Return the entry options as a standard dictionary."""
+
+        options = getattr(self._entry, "options", None)
+        if not options:
+            return {}
+        return dict(options)
+
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         errors: Dict[str, str] = {}
         wifi_cleared: set[str] = set()
@@ -480,7 +488,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                     cleaned.pop(CONF_UI_API_KEY, None)
                 else:
                     cleaned[CONF_UI_API_KEY] = normalized_key
-            merged = {**self._entry.data, **self._entry.options, **cleaned}
+            entry_options = self._entry_options()
+            merged = {**self._entry.data, **entry_options, **cleaned}
             normalized_host = ConfigFlow._normalize_host(merged.get(CONF_HOST))
             if host_provided and provided_host is None:
                 errors["base"] = "missing_host"
@@ -562,7 +571,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                                 data=current_data,
                             )
                     if CONF_UI_API_KEY in cleaned:
-                        current_options = dict(self._entry.options)
+                        current_options = self._entry_options()
                         normalized_key = cleaned[CONF_UI_API_KEY]
                         if normalized_key is None:
                             current_options.pop(CONF_UI_API_KEY, None)
@@ -606,7 +615,8 @@ class OptionsFlow(config_entries.OptionsFlow):
                     )
                     errors["base"] = "unknown"
 
-        current = {**self._entry.data, **self._entry.options}
+        entry_options = self._entry_options()
+        current = {**self._entry.data, **entry_options}
         host_default = ConfigFlow._normalize_host(current.get(CONF_HOST))
         if host_default is not None:
             current[CONF_HOST] = host_default

--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -177,6 +177,22 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                         lookup[identifier] = record
         return lookup
 
+    def _config_entry_options(self) -> Dict[str, Any]:
+        """Return the current config entry options as a mutable dict."""
+
+        entry = self._config_entry
+        if entry is None:
+            return {}
+        options = getattr(entry, "options", None)
+        if not options:
+            return {}
+        if isinstance(options, Mapping):
+            return dict(options)
+        try:
+            return dict(options)
+        except TypeError:
+            return {}
+
     def _resolve_wan_mac(
         self,
         link: Mapping[str, Any],
@@ -296,7 +312,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
         if self._config_entry is None:
             self._stored_gw_mac = normalized
             return
-        options = dict(self._config_entry.options)
+        options = self._config_entry_options()
         existing = normalize_mac(options.get(CONF_GW_MAC))
         if existing == normalized:
             self._stored_gw_mac = normalized

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -391,3 +391,42 @@ def test_options_flow_sanitizes_wifi_defaults(
     assert defaults[CONF_WIFI_GUEST] == ""
     assert defaults[CONF_WIFI_IOT] == ""
     assert defaults[CONF_UI_API_KEY] == ""
+
+
+def test_options_flow_handles_missing_options_mapping(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Options flow should tolerate config entries without an options dict."""
+
+    entry = cast(
+        ConfigEntry,
+        SimpleNamespace(
+            entry_id="missing-options",
+            data={
+                CONF_HOST: "udm.local",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+            },
+            options=None,
+        ),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_options_form(
+        self, *, step_id, data_schema=None, errors=None, description_placeholders=None
+    ):
+        captured["step_id"] = step_id
+        captured["schema"] = data_schema
+        return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+    monkeypatch.setattr(OptionsFlow, "async_show_form", fake_options_form, raising=False)
+
+    flow = OptionsFlow(entry)
+    flow.hass = hass  # type: ignore[assignment]
+
+    result = run(flow.async_step_init())
+
+    assert result["type"] == "form"
+    assert captured.get("step_id") == "init"
+    assert captured.get("schema") is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,26 @@
+"""Tests for the UniFi Gateway data coordinator."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from custom_components.unifi_gateway_refactored.coordinator import (
+    UniFiGatewayDataUpdateCoordinator,
+)
+from custom_components.unifi_gateway_refactored.const import CONF_GW_MAC
+from tests.stubs.homeassistant.config_entries import ConfigEntry
+
+
+def test_persist_gw_mac_handles_missing_options(hass) -> None:
+    """Coordinator should create a mutable options mapping when missing."""
+
+    entry = ConfigEntry(entry_id="test-entry", data={}, options=None)
+    coordinator = UniFiGatewayDataUpdateCoordinator(
+        hass,
+        MagicMock(),
+        config_entry=entry,
+    )
+
+    asyncio.run(coordinator._async_persist_gw_mac("AA:BB:CC:DD:EE:FF"))
+
+    assert entry.options == {CONF_GW_MAC: "aa:bb:cc:dd:ee:ff"}


### PR DESCRIPTION
## Summary
- add a helper to safely copy config entry options before mutating them
- use the helper when persisting the gateway MAC so updates work even when options is missing
- add regression coverage ensuring the coordinator handles entries without an options mapping

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e27268a6d08327b03ccb1ec2ecd17a