### PR TITLE
V.0.6.31

### DIFF
--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.29",
+  "version": "0.6.31",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/tests/stubs/voluptuous_serialize/__init__.py
+++ b/tests/stubs/voluptuous_serialize/__init__.py
@@ -1,0 +1,24 @@
+"""Lightweight stub of voluptuous_serialize for tests."""
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing during tests
+    from voluptuous.schema_builder import Schema as VolSchema  # type: ignore[import-not-found]
+else:  # pragma: no cover - runtime fallback when voluptuous is absent
+    VolSchema = Any
+
+
+def convert(schema: VolSchema | Any) -> dict[str, Any]:
+    """Return a minimal serialization for the provided schema.
+
+    The real library returns a structure describing the schema; for tests we only
+    need the function to be callable without raising and to produce a truthy
+    value when provided a valid schema.
+    """
+
+    if hasattr(schema, "schema"):
+        serialized = getattr(schema, "schema")
+    else:
+        serialized = schema
+    return {"type": "schema", "schema": serialized}


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
