### PR TITLE
dashbord yaml template

### DIFF
--- a/dashbord.yaml
+++ b/dashbord.yaml
@@ -1,0 +1,179 @@
+# =====================================================================
+# Unifi KAT01 Dashboard — WERSJA PARAMETRYZOWANA Z PARAMETREM VOUCHER (Lovelace YAML)
+# =====================================================================
+
+vars:
+  VOUCHER: &VOUCHER 65ca7619febe23401acd95fe
+  title: &title "Unifi KAT01 Dashboard"
+  icon: &icon "phu:ubiquiti-udm-pro"
+  theme: &theme "Frosted Glass Dark Lite"
+  visible_user: &visible_user d011ff1e9e89430ab550066d8c298e55
+
+  entities:
+    # Speedtest
+    speedtest_download: &e_speed_dl sensor.speedtest_download
+    speedtest_upload:   &e_speed_up sensor.speedtest_upload
+    speedtest_ping:     &e_speed_ping sensor.speedtest_ping
+
+    # Agregaty
+    lan:  &e_lan  sensor.lan
+    wlan: &e_wlan sensor.wlan
+
+    # Latencje WAN
+    wan_latency_cloudflare: &e_lat_cf  sensor.kat01_udm_pro_se_cloudflare_wan_latency
+    wan_latency_google:     &e_lat_go  sensor.kat01_udm_pro_se_google_wan_latency
+    wan_latency_msft:       &e_lat_ms  sensor.kat01_udm_pro_se_microsoft_wan_latency
+
+    # UDM/host — CPU/RAM/temperatury
+    udm_cpu_util: &e_udm_cpu   sensor.kat01_udm_pro_se_cpu_utilization
+    udm_mem_util: &e_udm_mem   sensor.kat01_udm_pro_se_memory_utilization
+    udm_cpu_temp: &e_udm_ctmp  sensor.kat01_udm_pro_se_kat01_udm_pro_se_cpu_temperature
+    udm_phy_temp: &e_udm_ptmp  sensor.kat01_udm_pro_se_kat01_udm_pro_se_phy_temperature
+
+    # Sieci LAN-y z detalami
+    lan_ui:      &e_lan_ui      sensor.lan_lan_ui
+    lan_iot:     &e_lan_iot     sensor.lan_lan_iot
+    lan_local:   &e_lan_local   sensor.lan_lan_local
+    lan_guest:   &e_lan_guest   sensor.lan_guest
+    lan_default: &e_lan_default sensor.lan_default
+
+    # Uptime infrastruktury
+    up_us8:        &e_up_us8        sensor.kat01_us_8_60w_uptime
+    up_usw_flex:   &e_up_usw_flex   sensor.kat01_usw_flex_uptime
+    up_usw_flex_m: &e_up_usw_flex_m sensor.kat01_usw_flex_mini_uptime
+    up_lite8poe:   &e_up_lite8poe   sensor.kat01_usw_lite_8_poe_uptime
+    up_udm:        &e_up_udm        sensor.kat01_udm_pro_se_uptime
+
+    # WAN info
+    wan_ip:  &e_wan_ip  sensor.wan_netia_wan1_ip
+    wan_isp: &e_wan_isp sensor.wan_netia_wan1_isp
+
+    # WiFi
+    ram_z:       &e_ram_z       sensor.ram_z
+    ram_ui:      &e_ram_ui      sensor.ram_ui
+    ram_ui_iot:  &e_ram_ui_iot  sensor.ram_ui_iot
+    ram5:        &e_ram5        sensor.ram5
+    ram_gu:      &e_ram_gu      sensor.ram_gu
+
+    # VPN serwery
+    vpn_wg_family:   &e_vpn_wg_family   sensor.vpn_wireguard_server_kat01_family
+    vpn_ovpn_srv:    &e_vpn_ovpn_srv    sensor.vpn_openvpn_server_kat01_openvpn
+    vpn_wg_main:     &e_vpn_wg_main     sensor.vpn_wireguard_server_kat01_wireguard
+    vpn_wg_family_l: &e_vpn_wg_family_l sensor.vpn_wireguard_server_family_lan
+    vpn_uid:         &e_vpn_uid         sensor.vpn_uid_server_kat01_udm_pro_se
+
+    # VPN klienci
+    vpn_cli_es: &e_vpn_cli_es sensor.vpn_openvpn_client_proton_hiszpania
+    vpn_cli_de: &e_vpn_cli_de sensor.vpn_openvpn_client_proton_niemcy
+    vpn_cli_vn: &e_vpn_cli_vn sensor.vpn_openvpn_client_proton_wietnam
+
+    # Firmware
+    upd_udm:       &e_upd_udm       update.kat01_udm_pro_se
+    upd_u6_ent:    &e_upd_u6_ent    update.kat01_u6_ent
+    upd_usw_fx_m2: &e_upd_usw_fx_m2 update.kat01_usw_flex_mini_2
+    upd_lite8poe:  &e_upd_lite8poe  update.kat01_usw_lite_8_poe
+    upd_usw_fx_m:  &e_upd_usw_fx_m  update.kat01_usw_flex_mini
+
+    alerts: &e_alerts sensor.alerts
+
+  style:
+    speed_gauge_max: &speed_gauge_max 1000
+    speed_up_max: &speed_up_max 350
+    speed_dl_inner_max: &speed_dl_inner_max 330
+    ping_max: &ping_max 30
+    color_ok: &color_ok "#4FCF58"
+    color_mid: &color_mid "#CF4FC6"
+    color_warn: &color_warn "#C6CF4F"
+
+type: sections
+title: *title
+icon: *icon
+theme: *theme
+visible:
+  - user: *visible_user
+
+max_columns: 2
+dense_section_placement: true
+subview: true
+
+# =====================
+# Sekcja WiFi (QR z parametrem VOUCHER)
+# =====================
+- type: grid
+  cards:
+    - type: heading
+      heading: WiFi
+      heading_style: title
+
+    - type: picture-elements
+      image: /local/wifi.jpg
+      elements:
+        - type: state-label
+          entity: !concat [ 'image.', *VOUCHER, '_qr_code' ]
+          attribute: wlan_name
+          style:
+            top: 15%
+            left: 50%
+            color: white
+            font-size: 180%
+            font-weight: bold
+            cursor: default
+          tap_action: { action: none }
+          hold_action: { action: none }
+
+        - type: image
+          entity: !concat [ 'image.', *VOUCHER, '_qr_code' ]
+          style:
+            top: 50%
+            left: 20%
+            width: 30%
+            cursor: default
+
+        - type: state-label
+          entity: !concat [ 'sensor.', *VOUCHER, '_voucher' ]
+          style:
+            top: 49%
+            left: 67%
+            background: rgba(11, 11, 11, 70%)
+            padding: 5px
+            height: 60px
+            color: white
+            border-radius: 12px
+            font-size: 200%
+            font-weight: bold
+            cursor: default
+          tap_action: { action: none }
+          hold_action: { action: none }
+
+        - type: state-label
+          entity: !concat [ 'sensor.', *VOUCHER, '_voucher' ]
+          attribute: duration
+          prefix: "Duration (ważność): "
+          style:
+            top: 39%
+            left: 67%
+            color: white
+            font-size: 90%
+            cursor: default
+          tap_action: { action: none }
+          hold_action: { action: none }
+
+        - type: service-button
+          title: Refresh/Odśwież
+          style:
+            transform: none
+            bottom: 1%
+            left: 35%
+          service: button.press
+          service_data:
+            entity_id: !concat [ 'button.', *VOUCHER, '_update' ]
+
+        - type: service-button
+          title: Create/Nowy
+          style:
+            transform: none
+            bottom: 1%
+            right: 2%
+          service: button.press
+          service_data:
+            entity_id: !concat [ 'button.', *VOUCHER, '_create' ]


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
