### PR TITLE
V.0.6.33

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -1167,11 +1167,12 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
 
         # Improved speedtest trigger logic
         interval = self._speedtest_interval
+        should_trigger = False
+        reason: str | None = None
         if interval > 0:
             last_ts = self._speedtest_last_timestamp(speedtest)
             now_ts = time.time()
 
-            should_trigger = False
             if not speedtest:
                 should_trigger = True
                 reason = "missing"
@@ -1185,7 +1186,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                 self._client.maybe_start_speedtest(cooldown_sec=cooldown)
                 _LOGGER.info(
                     "Triggered speedtest (reason=%s, interval=%ss, cooldown=%ss)",
-                    reason,
+                    reason or "interval",
                     interval,
                     cooldown
                 )

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -23,5 +23,5 @@
     "custom_components.unifi_gateway_refactored.cloud_client"
   ],
   "logo": "custom_components/unifi_gateway_refactored/logo.svg",
-  "icon": "custom_components/unifi_gateway_refactored/icon.svg"
+  "icon": "mdi:router-network"
 }

--- a/tests/test_coordinator_refresh.py
+++ b/tests/test_coordinator_refresh.py
@@ -20,6 +20,57 @@ class _DummyClient:
         return "dummy"
 
 
+class _FetchStubClient:
+    """Client stub exercising coordinator fetch behaviour."""
+
+    def __init__(self) -> None:
+        self.maybe_start_speedtest_called = False
+
+    # Connection metadata helpers
+    def instance_key(self) -> str:
+        return "stub"
+
+    def get_controller_api_url(self) -> str:
+        return "https://example/api"
+
+    def get_controller_url(self) -> str:
+        return "https://example/ui"
+
+    def get_site(self) -> str:
+        return "default"
+
+    # Data fetching helpers
+    def get_healthinfo(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_alerts(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_devices(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_networks(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_wan_links(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_wan_ips_from_devices(self) -> list[str]:
+        return []
+
+    def get_wlans(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_clients(self) -> list[dict[str, Any]]:
+        return []
+
+    def get_last_speedtest(self, *, cache_sec: int) -> dict[str, Any] | None:
+        return None
+
+    def maybe_start_speedtest(self, *, cooldown_sec: int) -> None:
+        self.maybe_start_speedtest_called = True
+
+
 class _TestCoordinator(UniFiGatewayDataUpdateCoordinator):
     def __init__(self, hass, client: UniFiOSClient, data: UniFiGatewayData) -> None:
         self._data_to_return = data
@@ -77,3 +128,19 @@ def test_coordinator_refresh_runs_in_executor(hass) -> None:
     assert calls[0][0] == coordinator._fetch_data
     assert coordinator.fetch_calls == 1
     assert coordinator.data == data
+
+
+def test_fetch_data_handles_zero_speedtest_interval(hass) -> None:
+    stub = _FetchStubClient()
+    client = cast(UniFiOSClient, stub)
+    coordinator = UniFiGatewayDataUpdateCoordinator(
+        hass,
+        client,
+        speedtest_interval=0,
+    )
+
+    data = coordinator._fetch_data()
+
+    assert isinstance(data, UniFiGatewayData)
+    assert data.health == []
+    assert not stub.maybe_start_speedtest_called


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
