### PR TITLE
V.0.6.34

### DIFF
--- a/custom_components/unifi_gateway_refactored/coordinator.py
+++ b/custom_components/unifi_gateway_refactored/coordinator.py
@@ -1167,15 +1167,19 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
 
         # Improved speedtest trigger logic
         interval = self._speedtest_interval
+        should_trigger = False
+        reason = "disabled"
         if interval > 0:
             last_ts = self._speedtest_last_timestamp(speedtest)
             now_ts = time.time()
 
-            should_trigger = False
             if not speedtest:
                 should_trigger = True
                 reason = "missing"
-            elif last_ts and (now_ts - last_ts) >= interval:
+            elif last_ts is None:
+                should_trigger = True
+                reason = "unknown age"
+            elif (now_ts - last_ts) >= interval:
                 should_trigger = True
                 reason = f"stale ({int(now_ts - last_ts)}s old)"
 
@@ -1187,7 +1191,7 @@ class UniFiGatewayDataUpdateCoordinator(DataUpdateCoordinator[UniFiGatewayData])
                     "Triggered speedtest (reason=%s, interval=%ss, cooldown=%ss)",
                     reason,
                     interval,
-                    cooldown
+                    cooldown,
                 )
             except APIError as err:
                 _LOGGER.warning("Failed to trigger speedtest: %s", err)

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.32",
+  "version": "0.6.34",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -22,6 +22,6 @@
     "custom_components.unifi_gateway_refactored.unifi_client",
     "custom_components.unifi_gateway_refactored.cloud_client"
   ],
-  "logo": "custom_components/unifi_gateway_refactored/logo.svg",
-  "icon": "custom_components/unifi_gateway_refactored/icon.svg"
+  "logo": "logo.svg",
+  "icon": "icon.svg"
 }


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
