### PR TITLE
V.0.6.35

### DIFF
--- a/custom_components/unifi_gateway_refactored/button.py
+++ b/custom_components/unifi_gateway_refactored/button.py
@@ -131,7 +131,6 @@ ManualRefreshCallback = Callable[[], Awaitable[object] | None]
 class NetworkStatusRefreshButton(ButtonEntity):
     _attr_name = "Refresh Network Status"
     _attr_icon = "mdi:refresh"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/unifi_gateway_refactored/manifest.json
+++ b/custom_components/unifi_gateway_refactored/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifi_gateway_refactored",
   "name": "UniFi Gateway Dashboard Analyzer",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "config_flow": true,
   "documentation": "https://github.com/rupert12pl/unifi_gatway_refacoty",
   "issue_tracker": "https://github.com/rupert12pl/unifi_gatway_refacoty/issues",

--- a/dashbord.yaml
+++ b/dashbord.yaml
@@ -24,6 +24,7 @@ vars:
     # Agregaty
     lan:  &e_lan  sensor.lan
     wlan: &e_wlan sensor.wlan
+    wan:  &e_wan  sensor.wan
 
     # Latencje WAN
     wan_latency_cloudflare: &e_lat_cf  sensor.kat03_udm_cloudflare_wan_latency
@@ -60,6 +61,7 @@ vars:
     ram_ui_iot:  &e_ram_ui_iot  sensor.ram_ui_iot
     ram5:        &e_ram5        sensor.ram5
     ram_gu:      &e_ram_gu      sensor.ram_gu
+    wlan_uptime: &e_wlan_uptime sensor.kat01_u6_ent_uptime
 
     # VPN serwery (zmieniono nazwę vpn_wg_family)
     vpn_wg_family:   &e_vpn_wg_family   sensor.vpn_wireguard_server_kat01_family
@@ -67,6 +69,11 @@ vars:
     vpn_wg_main:     &e_vpn_wg_main     sensor.vpn_wireguard_server_kat01_wireguard
     vpn_wg_family_l: &e_vpn_wg_family_l sensor.vpn_wireguard_server_family_lan
     vpn_uid:         &e_vpn_uid         sensor.vpn_uid_server_kat03_udm
+    vpn_wg_family_tpl:   &tpl_vpn_wg_family   "'sensor.vpn_wireguard_server_kat01_family'"
+    vpn_ovpn_srv_tpl:    &tpl_vpn_ovpn_srv    "'sensor.vpn_openvpn_server_kat01_openvpn'"
+    vpn_wg_main_tpl:     &tpl_vpn_wg_main     "'sensor.vpn_wireguard_server_kat01_wireguard'"
+    vpn_wg_family_l_tpl: &tpl_vpn_wg_family_l "'sensor.vpn_wireguard_server_family_lan'"
+    vpn_uid_tpl:         &tpl_vpn_uid         "'sensor.vpn_uid_server_kat03_udm'"
 
     # VPN klienci
     vpn_cli_es: &e_vpn_cli_es sensor.vpn_openvpn_client_proton_hiszpania
@@ -110,15 +117,26 @@ defaults:
     height: 75
     line_width: 1
     font_size: 70
-    hours_to_show: 72
-    points_per_hour: 10
+    hours_to_show: 48
+    points_per_hour: 6
     align_state: center
     show:
       fill: fade
 
   graph_common_dense: &graph_common_dense
     <<: *graph_common
-    points_per_hour: 20
+    hours_to_show: 24
+    points_per_hour: 12
+
+  tile_network: &tile_network
+    type: tile
+    color: accent
+    show_entity_picture: false
+    features:
+      - type: graph
+        graph: line
+        hours_to_show: 24
+        detail: 1
 
   ring_common: &ring_common
     type: custom:ring-tile
@@ -329,13 +347,9 @@ sections:
     cards:
       - { type: heading, heading: Performance, heading_style: title, icon: cil:docker-watchtower }
 
-      - type: custom:simple-swipe-card
-        card_spacing: 5
-        swipe_direction: vertical
-        auto_hide_pagination: 0
-        loop_mode: loopback
-        enable_auto_swipe: true
-        auto_swipe_interval: 4000
+      - type: grid
+        columns: 3
+        square: false
         cards:
           - <<: *ring_common
             entity: *e_lat_cf
@@ -346,15 +360,11 @@ sections:
           - <<: *ring_common
             entity: *e_lat_ms
             name: Microsoft
-        grid_options: { columns: 6, rows: 3 }
+        grid_options: { columns: 6 }
 
-      - type: custom:simple-swipe-card
-        card_spacing: 5
-        swipe_direction: vertical
-        auto_hide_pagination: 0
-        loop_mode: loopback
-        enable_auto_swipe: true
-        auto_swipe_interval: 4000
+      - type: grid
+        columns: 2
+        square: false
         cards:
           - <<: *ring_common
             entity: *e_udm_cpu
@@ -364,19 +374,15 @@ sections:
             name: RAM
           - <<: *ring_common
             entity: *e_udm_ctmp
-            name: CPU
+            name: CPU Temp
           - <<: *ring_common
             entity: *e_udm_ptmp
-            name: PHY
-        grid_options: { columns: 6, rows: 3 }
+            name: PHY Temp
+        grid_options: { columns: 6 }
 
-      - type: custom:simple-swipe-card
-        card_spacing: 5
-        swipe_direction: vertical
-        auto_hide_pagination: 0
-        loop_mode: loopback
-        enable_auto_swipe: true
-        auto_swipe_interval: 4000
+      - type: grid
+        columns: 2
+        square: false
         cards:
           - <<: *ring_common
             entity: *e_speed_dl
@@ -386,19 +392,16 @@ sections:
             entity: *e_speed_up
             name: Upload
             max: *speed_up_max
-        grid_options: { columns: 6, rows: 3 }
+        grid_options: { columns: 6 }
 
-      - type: custom:simple-swipe-card
-        swipe_direction: vertical
-        auto_hide_pagination: 0
-        loop_mode: infinite
-        enable_auto_swipe: true
-        auto_swipe_interval: 4000
+      - type: grid
+        columns: 3
+        square: false
         cards:
-          - { type: entity, entity: *e_wlan, attribute: num_user, state_color: true, icon: mdi:account-group-outline, grid_options: { columns: 6, rows: 3 } }
-          - { type: entity, entity: *e_alerts, grid_options: { columns: 6, rows: 3 } }
-          - { type: entity, entity: *e_lan, attribute: num_user, state_color: true, icon: mdi:account-group-outline, grid_options: { columns: 6, rows: 3 } }
-        grid_options: { columns: 6, rows: 3 }
+          - { type: entity, entity: *e_wlan, attribute: num_user, name: WLAN users, state_color: true, icon: mdi:account-group-outline }
+          - { type: entity, entity: *e_alerts, name: Alerts }
+          - { type: entity, entity: *e_lan, attribute: num_user, name: LAN users, state_color: true, icon: mdi:account-group-outline }
+        grid_options: { columns: 6 }
 
   # =====================
   # WAN/LAN/WLAN (Entities)
@@ -415,7 +418,7 @@ sections:
           - { entity: *e_lat_go,  name: Google latency,    icon: mdi:google }
           - { entity: *e_lat_ms,  name: Microsoft latency, icon: mdi:microsoft }
           - { entity: *e_lat_cf,  name: Cloudflare latency,icon: phu:cloudflare }
-          - entity: sensor.wan
+          - entity: *e_wan
             name: Gateways
             <<: *mer_devices
             entities:
@@ -427,7 +430,8 @@ sections:
       - { type: heading, icon: mdi:lan, heading: LAN, heading_style: subtitle,
           badges: [ { type: entity, entity: *e_lan, show_state: true, show_icon: true, state_content: user_total } ] }
 
-      - type: entities
+      - &lan_infrastructure_entities
+        type: entities
         state_color: false
         show_header_toggle: false
         entities:
@@ -446,7 +450,7 @@ sections:
       - type: entities
         entities:
           - { entity: *e_wlan, name: Status }
-          - { entity: sensor.kat01_u6_ent_uptime, name: Uptime, icon: mdi:wifi }
+          - { entity: *e_wlan_uptime, name: Uptime, icon: mdi:wifi }
           - entity: *e_wlan
             name: Users
             icon: mdi:wifi
@@ -474,18 +478,8 @@ sections:
 
       - { type: heading, icon: phu:ubiquiti-udm-pro, heading: Infrastructure, heading_style: subtitle }
 
-      - type: entities
+      - <<: *lan_infrastructure_entities
         title: Infrastructure
-        state_color: false
-        show_header_toggle: false
-        entities:
-          - { entity: *e_lan, name: Status }
-          - { entity: *e_up_us8,        name: "Uptime US 8",          icon: mdi:lan }
-          - { entity: *e_up_usw_flex,   name: "Uptime USW Flex",      icon: mdi:lan }
-          - { entity: *e_up_usw_flex_m, name: "Uptime USW Flex mini", icon: mdi:lan }
-          - { entity: *e_up_lite8poe,   name: "Uptime USW Lite 8POE", icon: mdi:lan }
-          - { entity: *e_up_udm,        name: "Uptime UDM Pro SE",    icon: mdi:lan }
-          - { entity: *e_lan, name: Switches, <<: *mer_devices }
 
   # =====================
   # VPN — Serwery
@@ -549,28 +543,28 @@ sections:
       - type: custom:html-template-card
         ignore_line_breaks: true
         content: >
-          <big><span style="color: grey;"><center>{{ state_attr('sensor.vpn_wireguard_server_kat01_family','vpn_name') }}</center></big>
-          {{ state_attr('sensor.vpn_wireguard_server_kat01_family','connected_clients_html') }}
+          <big><span style="color: grey;"><center>{{ state_attr(*tpl_vpn_wg_family, "vpn_name") }}</center></big>
+          {{ state_attr(*tpl_vpn_wg_family, "connected_clients_html") }}
       - type: custom:html-template-card
         ignore_line_breaks: true
         content: >
-          <big><span style="color: grey;"><center>{{ state_attr('sensor.vpn_openvpn_server_kat01_openvpn','vpn_name') }}</center></big>
-          {{ state_attr('sensor.vpn_openvpn_server_kat01_openvpn','connected_clients_html') }}
+          <big><span style="color: grey;"><center>{{ state_attr(*tpl_vpn_ovpn_srv, "vpn_name") }}</center></big>
+          {{ state_attr(*tpl_vpn_ovpn_srv, "connected_clients_html") }}
       - type: custom:html-template-card
         ignore_line_breaks: true
         content: >
-          <big><span style="color: grey;"><center>{{ state_attr('sensor.vpn_wireguard_server_kat01_wireguard','vpn_name') }}</center></big>
-          {{ state_attr('sensor.vpn_wireguard_server_kat01_wireguard','connected_clients_html') }}
+          <big><span style="color: grey;"><center>{{ state_attr(*tpl_vpn_wg_main, "vpn_name") }}</center></big>
+          {{ state_attr(*tpl_vpn_wg_main, "connected_clients_html") }}
       - type: custom:html-template-card
         ignore_line_breaks: true
         content: >
-          <big><span style="color: grey;"><center>{{ state_attr('sensor.vpn_wireguard_server_family_lan','vpn_name') }}</center></big>
-          {{ state_attr('sensor.vpn_wireguard_server_family_lan','connected_clients_html') }}
+          <big><span style="color: grey;"><center>{{ state_attr(*tpl_vpn_wg_family_l, "vpn_name") }}</center></big>
+          {{ state_attr(*tpl_vpn_wg_family_l, "connected_clients_html") }}
       - type: custom:html-template-card
         ignore_line_breaks: true
         content: >
-          <big><span style="color: grey;"><center>{{ state_attr('sensor.vpn_uid_server_kat03_udm','vpn_name') }}</center></big>
-          {{ state_attr('sensor.vpn_uid_server_kat03_udm','connected_clients_html') }}
+          <big><span style="color: grey;"><center>{{ state_attr(*tpl_vpn_uid, "vpn_name") }}</center></big>
+          {{ state_attr(*tpl_vpn_uid, "connected_clients_html") }}
 
   # =====================
   # VPN — Klienci
@@ -671,15 +665,26 @@ sections:
     cards:
       - { type: heading, heading: WiFi, heading_style: title }
 
-      - type: entities
-        state_color: false
-        show_header_toggle: false
-        entities:
-          - { entity: *e_ram_z }
-          - { entity: *e_ram_ui }
-          - { entity: *e_ram_ui_iot }
-          - { entity: *e_ram5 }
-          - { entity: *e_ram_gu }
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - <<: *tile_network
+            entity: *e_ram_z
+            name: RAM-Z
+          - <<: *tile_network
+            entity: *e_ram_ui
+            name: RAM-UI
+          - <<: *tile_network
+            entity: *e_ram_ui_iot
+            name: RAM-UI IoT
+          - <<: *tile_network
+            entity: *e_ram5
+            name: RAM-5G
+          - <<: *tile_network
+            entity: *e_ram_gu
+            name: RAM-Guest
+        grid_options: { columns: 12 }
 
       - <<: *graph_common_dense
         name: Users


### PR DESCRIPTION
## Summary
- [ ] Uses LAN/WAN fetch helper for VPN (same session/timeouts/site/base).
- [ ] No per-connection VPN entities created.
- [ ] `configured_vpn` attribute present; `attempts` and `winner_paths` filled.
- [ ] Handles 400/404 without raising; diagnostics populated.
- [ ] No secrets in logs or attributes; redaction verified.
- [ ] No weak crypto (MD5/SHA-1/RC4/DES/3DES); any hashing for IDs uses SHA-256.
- [ ] TLS verify on by default; timeouts finite; retries bounded.
- [ ] Unique IDs stable and include `entry.entry_id`.
- [ ] Type hints added; `ruff`/`flake8`/`mypy`/`bandit` pass.
- [ ] Tests for legacy/v2 fallback and double-prefix prevention pass.
